### PR TITLE
[_] fix path to kyber.wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ BUILD_DIR = build
 CLEANCSS = ./node_modules/.bin/cleancss
 DEPLOY_DIR = libs
 LIBJITSIMEET_DIR = node_modules/lib-jitsi-meet
-DASHLANE_PQC_DIR = node_modules/@dashlane/pqc-kem-kyber512-browser/dist
 OLM_DIR = node_modules/@matrix-org/olm
 TF_WASM_DIR = node_modules/@tensorflow/tfjs-backend-wasm/dist/
 RNNOISE_WASM_DIR = node_modules/@jitsi/rnnoise-wasm/dist
@@ -70,7 +69,7 @@ deploy-lib-jitsi-meet:
 
 deploy-pqc-kem-kyber512-browser-wasm:
 	cp \
-		$(DASHLANE_PQC_DIR)/*.wasm \
+		$(LIBJITSIMEET_DIR)/dist/umd/pqc-kem-kyber512.wasm \
 		$(DEPLOY_DIR)
 
 deploy-olm:


### PR DESCRIPTION
## Description

meet-web doesn't have kyber dependency, so node_modules/@dashlane is empty, and npm cannot copy pqc-kem-kyber512.wasm. But lib-jitsi-meet has kyber so we can copy the wasm from there

## Related Issues



## Related Pull Requests



## Checklist

-   [ ] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [ ] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?


## Additional Notes
