### PR TITLE
[PB-3795] feature/Fix speaker mode

### DIFF
--- a/react/features/app/types.ts
+++ b/react/features/app/types.ts
@@ -39,7 +39,7 @@ import { IE2EEState } from "../e2ee/reducer";
 import { IEtherpadState } from "../etherpad/reducer";
 import { IFaceLandmarksState } from "../face-landmarks/reducer";
 import { IFeedbackState } from "../feedback/reducer";
-import { IFilmstripState } from "../filmstrip/reducer";
+
 import { IFollowMeState } from "../follow-me/reducer";
 import { IGifsState } from "../gifs/reducer";
 import { IGoogleApiState } from "../google-api/reducer";
@@ -83,6 +83,7 @@ import { IVirtualBackground } from "../virtual-background/reducer";
 import { IVisitorsState } from "../visitors/reducer";
 import { IWebHid } from "../web-hid/reducer";
 import { IWhiteboardState } from "../whiteboard/reducer";
+import { IFilmstripState } from '../filmstrip/reducer';
 
 
 export interface IStore {

--- a/react/features/base/meet/views/Conference/components/JoinConference.tsx
+++ b/react/features/base/meet/views/Conference/components/JoinConference.tsx
@@ -35,6 +35,8 @@ import ConferenceControlsWrapper from "../containers/ConferenceControlsWrapper";
 import VideoGalleryWrapper from "../containers/VideoGalleryWrapper";
 import { DEFAULT_STATE } from "../../../../known-domains/reducer";
 import PersistenceRegistry from "../../../../redux/PersistenceRegistry";
+import { setConferenceViewMode } from "../../../../../filmstrip/actions.web";
+import { ViewMode } from "../../../../../filmstrip/reducer";
 
 /**
  * DOM events for when full screen mode has changed. Different browsers need
@@ -87,6 +89,7 @@ interface IProps extends AbstractProps, WithTranslation {
      */
     _showPrejoin: boolean;
 
+    viewMode: ViewMode;
     dispatch: any;
 }
 
@@ -96,12 +99,9 @@ interface IProps extends AbstractProps, WithTranslation {
 class Conference extends AbstractConference<IProps, any> {
     _originalOnMouseMove: Function;
     _originalOnShowToolbar: Function;
-    state = {
-        videoMode: "gallery" as Mode,
-    };
 
     _onSetVideoModeClicked = (newMode: Mode) => {
-        this.setState({ videoMode: newMode });
+        this.props.dispatch(setConferenceViewMode(newMode))
     };
     /**
      * Initializes a new Conference instance.
@@ -159,9 +159,9 @@ class Conference extends AbstractConference<IProps, any> {
             _overflowDrawer,
             _showLobby,
             _showPrejoin,
+            viewMode,
             t,
         } = this.props;
-        const { videoMode } = this.state;
 
         return (
             <>
@@ -176,10 +176,10 @@ class Conference extends AbstractConference<IProps, any> {
                     <ConferenceInfo />
                     <Notice />
                     <div onTouchStart={this._onVidespaceTouchStart}>
-                        <Header mode={videoMode} translate={t} onSetModeClicked={this._onSetVideoModeClicked} />
+                        <Header mode={viewMode} translate={t} onSetModeClicked={this._onSetVideoModeClicked} />
                         <div className="flex">
                             {/* <LargeVideoWeb /> */}
-                            <VideoGalleryWrapper videoMode={videoMode} />
+                            <VideoGalleryWrapper videoMode={viewMode} />
                         </div>
                         {_showPrejoin || _showLobby || (
                             <>
@@ -319,6 +319,7 @@ class Conference extends AbstractConference<IProps, any> {
  */
 function _mapStateToProps(state: IReduxState) {
     const { mouseMoveCallbackInterval } = state["features/base/config"];
+    const { viewMode } = state["features/filmstrip"];
     const { overflowDrawer } = state["features/toolbox"];
 
     return {
@@ -330,6 +331,7 @@ function _mapStateToProps(state: IReduxState) {
         _roomName: getConferenceNameForTitle(state),
         _showLobby: getIsLobbyVisible(state),
         _showPrejoin: isPrejoinPageVisible(state),
+        viewMode,
     };
 }
 

--- a/react/features/base/meet/views/Conference/components/VideoSpeaker.tsx
+++ b/react/features/base/meet/views/Conference/components/VideoSpeaker.tsx
@@ -19,7 +19,7 @@ const VideoSpeaker = ({ participants, translate }: VideoSpeakerProps) => {
                     key={localParticipant.id}
                     participant={localParticipant}
                     translate={translate}
-                    className="absolute bottom-4 right-4 h-[17%] w-[15%]"
+                     className="absolute sm:bottom-4 bottom-24 right-4 aspect-video w-1/5 max-w-xs"
                 />
             )}
         </div>

--- a/react/features/conference/components/web/Conference.tsx
+++ b/react/features/conference/components/web/Conference.tsx
@@ -36,6 +36,8 @@ import { default as Notice } from "./Notice";
 
 import ConferenceControlsWrapper from "../../../base/meet/views/Conference/containers/ConferenceControlsWrapper";
 import VideoGalleryWrapper from "../../../base/meet/views/Conference/containers/VideoGalleryWrapper";
+import { ViewMode } from '../../../filmstrip/reducer';
+import { setConferenceViewMode } from '../../../filmstrip/actions.web';
 
 /**
  * DOM events for when full screen mode has changed. Different browsers need
@@ -96,6 +98,8 @@ interface IProps extends AbstractProps, WithTranslation {
     dispatch: any;
 
     isParticipantsPaneOpened: boolean;
+
+    viewMode: ViewMode;
 }
 
 /**
@@ -109,7 +113,7 @@ class Conference extends AbstractConference<IProps, any> {
     };
 
     _onSetVideoModeClicked = (newMode: Mode) => {
-        this.setState({ videoMode: newMode });
+        this.props.dispatch(setConferenceViewMode(newMode))
     };
     /**
      * Initializes a new Conference instance.
@@ -199,9 +203,9 @@ class Conference extends AbstractConference<IProps, any> {
             _overflowDrawer,
             _showLobby,
             _showPrejoin,
+            viewMode,
             t,
         } = this.props;
-        const { videoMode } = this.state;
 
         return (
             <div
@@ -222,10 +226,10 @@ class Conference extends AbstractConference<IProps, any> {
                     <ConferenceInfo />
                     <Notice />
                     <div onTouchStart={this._onVidespaceTouchStart}>
-                        <Header mode={videoMode} translate={t} onSetModeClicked={this._onSetVideoModeClicked} />
+                        <Header mode={viewMode} translate={t} onSetModeClicked={this._onSetVideoModeClicked} />
                         <div className="flex">
                             {/* <LargeVideoWeb /> */}
-                            <VideoGalleryWrapper videoMode={videoMode} />
+                            <VideoGalleryWrapper videoMode={viewMode} />
                         </div>
                         {_showPrejoin || _showLobby || (
                             <>
@@ -395,6 +399,7 @@ class Conference extends AbstractConference<IProps, any> {
  */
 function _mapStateToProps(state: IReduxState) {
     const { backgroundAlpha, mouseMoveCallbackInterval } = state["features/base/config"];
+    const { viewMode } = state["features/filmstrip"];
     const { overflowDrawer } = state["features/toolbox"];
 
     return {
@@ -407,6 +412,7 @@ function _mapStateToProps(state: IReduxState) {
         _roomName: getConferenceNameForTitle(state),
         _showLobby: getIsLobbyVisible(state),
         _showPrejoin: isPrejoinPageVisible(state),
+        viewMode,
     };
 }
 

--- a/react/features/filmstrip/actionTypes.ts
+++ b/react/features/filmstrip/actionTypes.ts
@@ -229,3 +229,11 @@ export const SET_SCREENSHARING_TILE_DIMENSIONS = 'SET_SCREENSHARING_TILE_DIMENSI
  * }
  */
 export const SET_TOP_PANEL_VISIBILITY = 'SET_TOP_PANEL_VISIBILITY';
+
+/**
+ * The type of Redux action which sets the conference view mode.
+ * {
+ *     type: SET_VIEW_MODE
+ * }
+ */
+export const SET_VIEW_MODE = 'SET_VIEW_MODE';

--- a/react/features/filmstrip/actions.web.ts
+++ b/react/features/filmstrip/actions.web.ts
@@ -26,6 +26,7 @@ import {
     SET_USER_FILMSTRIP_WIDTH,
     SET_USER_IS_RESIZING,
     SET_VERTICAL_VIEW_DIMENSIONS,
+    SET_VIEW_MODE,
     SET_VOLUME,
     TOGGLE_PIN_STAGE_PARTICIPANT
 } from './actionTypes';
@@ -55,6 +56,7 @@ import {
     isStageFilmstripAvailable,
     isStageFilmstripTopPanel
     , showGridInVerticalView } from './functions.web';
+import { ViewMode } from './reducer';
 
 export * from './actions.any';
 
@@ -587,5 +589,18 @@ export function setScreenshareFilmstripParticipant(participantId?: string) {
     return {
         type: SET_SCREENSHARE_FILMSTRIP_PARTICIPANT,
         participantId
+    };
+}
+
+/**
+ * Sets the filmstrip view mode
+ *
+ * @param {ViewMode} viewMode - The view mode to be set.
+ * @returns {Object}
+ */
+export function setConferenceViewMode(viewMode?: ViewMode) {
+    return {
+        type: SET_VIEW_MODE,
+        viewMode
     };
 }

--- a/react/features/filmstrip/reducer.ts
+++ b/react/features/filmstrip/reducer.ts
@@ -21,11 +21,12 @@ import {
     SET_USER_FILMSTRIP_WIDTH,
     SET_USER_IS_RESIZING,
     SET_VERTICAL_VIEW_DIMENSIONS,
+    SET_VIEW_MODE,
     SET_VISIBLE_REMOTE_PARTICIPANTS,
     SET_VOLUME
 } from './actionTypes';
 
-const DEFAULT_STATE = {
+const DEFAULT_STATE: IFilmstripState = {
 
     /**
      * The list of participants to be displayed on the stage filmstrip.
@@ -176,13 +177,22 @@ const DEFAULT_STATE = {
          * Width set by user resize. Used as the preferred width.
          */
         userSet: null
-    }
+    },
+    /**
+     * The selected view mode in a conference
+     *
+     * @public
+     * @type { "gallery" | "speaker"}
+     */
+    viewMode: "gallery"
 };
 
 interface IDimensions {
     height: number;
     width: number;
 }
+
+export type ViewMode = "gallery" | "speaker";
 
 interface IFilmstripDimensions {
     columns?: number;
@@ -248,12 +258,18 @@ export interface IFilmstripState {
         current: number | null;
         userSet: number | null;
     };
+    viewMode: ViewMode;
 }
 
 ReducerRegistry.register<IFilmstripState>(
     'features/filmstrip',
     (state = DEFAULT_STATE, action): IFilmstripState => {
         switch (action.type) {
+        case SET_VIEW_MODE:
+            return {
+                ...state,
+                viewMode: action.viewMode
+            }
         case SET_FILMSTRIP_ENABLED:
             return {
                 ...state,

--- a/react/features/video-layout/functions.any.ts
+++ b/react/features/video-layout/functions.any.ts
@@ -35,6 +35,10 @@ export function getAutoPinSetting() {
  * @returns {string}
  */
 export function getCurrentLayout(state: IReduxState) {
+
+    if (state["features/filmstrip"].viewMode === "speaker")
+        return LAYOUTS.VERTICAL_FILMSTRIP_VIEW;
+
     if (navigator.product === 'ReactNative') {
         // FIXME: what should this return?
         return undefined;


### PR DESCRIPTION
## Description

- Fixed speaker mode when there are more than two participants
- Fixed self video size on small screens

## Related Issues

-

## Related Pull Requests

-

## Checklist

-   [x] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [ ] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

- Begin a conference with 3 or more users, and check if the speaker user changes when speak
- In a conference with speaker mode screen, resize browser to check small size

## Additional Notes
