### PR TITLE
[PB-4217] feature/Gallery view in wide screens

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,5 +3,7 @@ module.exports = {
         '@jitsi/eslint-config'
     ],
     'ignorePatterns': [ '*.d.ts' ],
-    'linebreak-style': 'off'
+    rules: {
+        'linebreak-style': ['error', 'unix'],
+    },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,5 @@
 module.exports = {
-    'extends': [
-        '@jitsi/eslint-config'
-    ],
+    "extends": "@internxt/eslint-config-internxt",
     'ignorePatterns': [ '*.d.ts' ],
     rules: {
         'linebreak-style': ['error', 'unix'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "@giphy/react-components": "6.8.1",
                 "@giphy/react-native-sdk": "2.3.0",
                 "@internxt/css-config": "^1.0.2",
+                "@internxt/eslint-config-internxt": "^2.0.0",
                 "@internxt/lib": "^1.2.1",
                 "@internxt/sdk": "=1.9.8",
                 "@internxt/ui": "^0.0.22",
@@ -3076,7 +3077,6 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
             "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
-            "dev": true,
             "dependencies": {
                 "eslint-visitor-keys": "^3.3.0"
             },
@@ -3091,7 +3091,6 @@
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -3103,7 +3102,6 @@
             "version": "4.10.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
             "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
-            "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
@@ -3426,6 +3424,23 @@
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/@internxt/eslint-config-internxt": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@internxt/eslint-config-internxt/-/eslint-config-internxt-2.0.0.tgz",
+            "integrity": "sha512-GFs8jKDolU1fZeEkd1TVMuJLYaCcyJsiRM4/BJkTrU3IrVRWupduAgPU9XtBagLWtZWLO8Oycive7XjwXfxjiw==",
+            "license": "MIT",
+            "dependencies": {
+                "eslint-config-prettier": "^9.1.0",
+                "typescript-eslint": "^8.15.0"
+            },
+            "engines": {
+                "node": ">=14.17.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=9.0.0",
+                "typescript": ">=4.2.0"
             }
         },
         "node_modules/@internxt/lib": {
@@ -12603,6 +12618,18 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/eslint-config-prettier": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+            "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+            "license": "MIT",
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
+            }
+        },
         "node_modules/eslint-import-resolver-node": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -13948,6 +13975,12 @@
             "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
             "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
         },
+        "node_modules/graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+            "license": "MIT"
+        },
         "node_modules/gzip-size": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -14415,7 +14448,6 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
             "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -17793,8 +17825,7 @@
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "dev": true
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
         },
         "node_modules/natural-compare-lite": {
             "version": "1.4.0",
@@ -22808,6 +22839,18 @@
             "integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==",
             "dev": true
         },
+        "node_modules/ts-api-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4"
+            }
+        },
         "node_modules/ts-easing": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
@@ -23105,6 +23148,248 @@
             },
             "engines": {
                 "node": ">=12.20"
+            }
+        },
+        "node_modules/typescript-eslint": {
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.29.1.tgz",
+            "integrity": "sha512-f8cDkvndhbQMPcysk6CUSGBWV+g1utqdn71P5YKwMumVMOG/5k7cHq0KyG4O52nB0oKS4aN2Tp5+wB4APJGC+w==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.29.1",
+                "@typescript-eslint/parser": "8.29.1",
+                "@typescript-eslint/utils": "8.29.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.29.1.tgz",
+            "integrity": "sha512-ba0rr4Wfvg23vERs3eB+P3lfj2E+2g3lhWcCVukUuhtcdUx5lSIFZlGFEBHKr+3zizDa/TvZTptdNHVZWAkSBg==",
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.10.0",
+                "@typescript-eslint/scope-manager": "8.29.1",
+                "@typescript-eslint/type-utils": "8.29.1",
+                "@typescript-eslint/utils": "8.29.1",
+                "@typescript-eslint/visitor-keys": "8.29.1",
+                "graphemer": "^1.4.0",
+                "ignore": "^5.3.1",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^2.0.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.29.1.tgz",
+            "integrity": "sha512-zczrHVEqEaTwh12gWBIJWj8nx+ayDcCJs06yoNMY0kwjMWDM6+kppljY+BxWI06d2Ja+h4+WdufDcwMnnMEWmg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "8.29.1",
+                "@typescript-eslint/types": "8.29.1",
+                "@typescript-eslint/typescript-estree": "8.29.1",
+                "@typescript-eslint/visitor-keys": "8.29.1",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.1.tgz",
+            "integrity": "sha512-2nggXGX5F3YrsGN08pw4XpMLO1Rgtnn4AzTegC2MDesv6q3QaTU5yU7IbS1tf1IwCR0Hv/1EFygLn9ms6LIpDA==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.29.1",
+                "@typescript-eslint/visitor-keys": "8.29.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.29.1.tgz",
+            "integrity": "sha512-DkDUSDwZVCYN71xA4wzySqqcZsHKic53A4BLqmrWFFpOpNSoxX233lwGu/2135ymTCR04PoKiEEEvN1gFYg4Tw==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "8.29.1",
+                "@typescript-eslint/utils": "8.29.1",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^2.0.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.1.tgz",
+            "integrity": "sha512-VT7T1PuJF1hpYC3AGm2rCgJBjHL3nc+A/bhOp9sGMKfi5v0WufsX/sHCFBfNTx2F+zA6qBc/PD0/kLRLjdt8mQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.1.tgz",
+            "integrity": "sha512-l1enRoSaUkQxOQnbi0KPUtqeZkSiFlqrx9/3ns2rEDhGKfTa+88RmXqedC1zmVTOWrLc2e6DEJrTA51C9iLH5g==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.29.1",
+                "@typescript-eslint/visitor-keys": "8.29.1",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^2.0.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.29.1.tgz",
+            "integrity": "sha512-QAkFEbytSaB8wnmB+DflhUPz6CLbFWE2SnSCrRMEa+KnXIzDYbpsn++1HGvnfAsUY44doDXmvRkO5shlM/3UfA==",
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@typescript-eslint/scope-manager": "8.29.1",
+                "@typescript-eslint/types": "8.29.1",
+                "@typescript-eslint/typescript-estree": "8.29.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.1.tgz",
+            "integrity": "sha512-RGLh5CRaUEf02viP5c1Vh1cMGffQscyHe7HPAzGpfmfflFg1wUz2rYxd+OZqwpeypYvZ8UxSxuIpF++fmOzEcg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.29.1",
+                "eslint-visitor-keys": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/eslint-visitor-keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@giphy/react-components": "6.8.1",
         "@giphy/react-native-sdk": "2.3.0",
         "@internxt/css-config": "^1.0.2",
+        "@internxt/eslint-config-internxt": "^2.0.0",
         "@internxt/lib": "^1.2.1",
         "@internxt/sdk": "=1.9.8",
         "@internxt/ui": "^0.0.22",

--- a/react/features/base/meet/general/hooks/useAspectRatio.test.ts
+++ b/react/features/base/meet/general/hooks/useAspectRatio.test.ts
@@ -5,6 +5,18 @@ import { useAspectRatio } from './useAspectRatio';
 describe('useAspectRatio', () => {
   const originalInnerWidth = window.innerWidth;
   const originalInnerHeight = window.innerHeight;
+
+  const RATIO_16_BY_9 = 16 / 9;
+
+  const DEFAULT_HEIGHT = 900;
+  const EXACT_16_BY_9_WIDTH = Math.round(DEFAULT_HEIGHT * RATIO_16_BY_9);
+  const WIDER_THAN_16_BY_9_WIDTH = 1920;
+  const LESS_WIDE_THAN_16_BY_9_WIDTH = 1200;
+
+  const RESIZE_HEIGHT = 1080;
+  const RESIZE_WIDTH = 2560;
+  const RESIZE_RATIO = RESIZE_WIDTH / RESIZE_HEIGHT;
+
   let resizeCallback;
 
   beforeEach(() => {
@@ -24,17 +36,17 @@ describe('useAspectRatio', () => {
   });
 
   it('should return the correct aspect ratio', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 1600 });
-    Object.defineProperty(window, 'innerHeight', { value: 900 });
+    Object.defineProperty(window, 'innerWidth', { value: EXACT_16_BY_9_WIDTH });
+    Object.defineProperty(window, 'innerHeight', { value: DEFAULT_HEIGHT });
 
     const { result } = renderHook(() => useAspectRatio());
 
-    expect(result.current.aspectRatio).toBeCloseTo(1.778, 3);
+    expect(result.current.aspectRatio).toBeCloseTo(RATIO_16_BY_9, 3);
   });
 
   it('should correctly detect when the ratio is wider than 16:9', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 1920 });
-    Object.defineProperty(window, 'innerHeight', { value: 900 });
+    Object.defineProperty(window, 'innerWidth', { value: WIDER_THAN_16_BY_9_WIDTH });
+    Object.defineProperty(window, 'innerHeight', { value: DEFAULT_HEIGHT });
 
     const { result } = renderHook(() => useAspectRatio());
 
@@ -42,18 +54,18 @@ describe('useAspectRatio', () => {
   });
 
   it('should correctly detect when the ratio is exactly 16:9', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 1600 });
-    Object.defineProperty(window, 'innerHeight', { value: 900 });
+    Object.defineProperty(window, 'innerWidth', { value: EXACT_16_BY_9_WIDTH });
+    Object.defineProperty(window, 'innerHeight', { value: DEFAULT_HEIGHT });
 
     const { result } = renderHook(() => useAspectRatio());
 
-    expect(result.current.aspectRatio).toBeCloseTo(16/9, 3);
+    expect(result.current.aspectRatio).toBeCloseTo(RATIO_16_BY_9, 3);
     expect(result.current.isWiderThan16by9).toBe(false);
   });
 
   it('should correctly detect when the ratio is less wide than 16:9', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 1200 });
-    Object.defineProperty(window, 'innerHeight', { value: 900 });
+    Object.defineProperty(window, 'innerWidth', { value: LESS_WIDE_THAN_16_BY_9_WIDTH });
+    Object.defineProperty(window, 'innerHeight', { value: DEFAULT_HEIGHT });
 
     const { result } = renderHook(() => useAspectRatio());
 
@@ -61,20 +73,20 @@ describe('useAspectRatio', () => {
   });
 
   it('should provide the correct containerStyle for windows wider than 16:9', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 1920 });
-    Object.defineProperty(window, 'innerHeight', { value: 900 });
+    Object.defineProperty(window, 'innerWidth', { value: WIDER_THAN_16_BY_9_WIDTH });
+    Object.defineProperty(window, 'innerHeight', { value: DEFAULT_HEIGHT });
 
     const { result } = renderHook(() => useAspectRatio());
 
     expect(result.current.containerStyle).toEqual({
-      maxWidth: `${900 * (16/9)}px`,
+      maxWidth: `${DEFAULT_HEIGHT * RATIO_16_BY_9}px`,
       margin: '0 auto'
     });
   });
 
   it('should provide an empty containerStyle for windows less wide than 16:9', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 1200 });
-    Object.defineProperty(window, 'innerHeight', { value: 900 });
+    Object.defineProperty(window, 'innerWidth', { value: LESS_WIDE_THAN_16_BY_9_WIDTH });
+    Object.defineProperty(window, 'innerHeight', { value: DEFAULT_HEIGHT });
 
     const { result } = renderHook(() => useAspectRatio());
 
@@ -82,24 +94,24 @@ describe('useAspectRatio', () => {
   });
 
   it('should update values when window size changes', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 1600 });
-    Object.defineProperty(window, 'innerHeight', { value: 900 });
+    Object.defineProperty(window, 'innerWidth', { value: EXACT_16_BY_9_WIDTH });
+    Object.defineProperty(window, 'innerHeight', { value: DEFAULT_HEIGHT });
 
     const { result } = renderHook(() => useAspectRatio());
 
-    expect(result.current.aspectRatio).toBeCloseTo(1.778, 3);
+    expect(result.current.aspectRatio).toBeCloseTo(RATIO_16_BY_9, 3);
     expect(result.current.isWiderThan16by9).toBe(false);
 
     act(() => {
-      Object.defineProperty(window, 'innerWidth', { value: 2560 });
-      Object.defineProperty(window, 'innerHeight', { value: 1080 });
+      Object.defineProperty(window, 'innerWidth', { value: RESIZE_WIDTH });
+      Object.defineProperty(window, 'innerHeight', { value: RESIZE_HEIGHT });
       resizeCallback();
     });
 
-    expect(result.current.aspectRatio).toBeCloseTo(2.37, 2);
+    expect(result.current.aspectRatio).toBeCloseTo(RESIZE_RATIO, 2);
     expect(result.current.isWiderThan16by9).toBe(true);
     expect(result.current.containerStyle).toEqual({
-      maxWidth: `${1080 * (16/9)}px`,
+      maxWidth: `${RESIZE_HEIGHT * RATIO_16_BY_9}px`,
       margin: '0 auto'
     });
   });

--- a/react/features/base/meet/general/hooks/useAspectRatio.test.ts
+++ b/react/features/base/meet/general/hooks/useAspectRatio.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAspectRatio } from './useAspectRatio';
+
+describe('useAspectRatio', () => {
+  const originalInnerWidth = window.innerWidth;
+  const originalInnerHeight = window.innerHeight;
+  let resizeCallback;
+
+  beforeEach(() => {
+    vi.spyOn(window, 'addEventListener').mockImplementation((event, callback) => {
+      if (event === 'resize') {
+        resizeCallback = callback;
+      }
+    });
+
+    vi.spyOn(window, 'removeEventListener').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: originalInnerWidth });
+    Object.defineProperty(window, 'innerHeight', { value: originalInnerHeight });
+    vi.restoreAllMocks();
+  });
+
+  it('should return the correct aspect ratio', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1600 });
+    Object.defineProperty(window, 'innerHeight', { value: 900 });
+
+    const { result } = renderHook(() => useAspectRatio());
+
+    expect(result.current.aspectRatio).toBeCloseTo(1.778, 3);
+  });
+
+  it('should correctly detect when the ratio is wider than 16:9', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1920 });
+    Object.defineProperty(window, 'innerHeight', { value: 900 });
+
+    const { result } = renderHook(() => useAspectRatio());
+
+    expect(result.current.isWiderThan16by9).toBe(true);
+  });
+
+  it('should correctly detect when the ratio is exactly 16:9', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1600 });
+    Object.defineProperty(window, 'innerHeight', { value: 900 });
+
+    const { result } = renderHook(() => useAspectRatio());
+
+    expect(result.current.aspectRatio).toBeCloseTo(16/9, 3);
+    expect(result.current.isWiderThan16by9).toBe(false);
+  });
+
+  it('should correctly detect when the ratio is less wide than 16:9', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1200 });
+    Object.defineProperty(window, 'innerHeight', { value: 900 });
+
+    const { result } = renderHook(() => useAspectRatio());
+
+    expect(result.current.isWiderThan16by9).toBe(false);
+  });
+
+  it('should provide the correct containerStyle for windows wider than 16:9', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1920 });
+    Object.defineProperty(window, 'innerHeight', { value: 900 });
+
+    const { result } = renderHook(() => useAspectRatio());
+
+    expect(result.current.containerStyle).toEqual({
+      maxWidth: `${900 * (16/9)}px`,
+      margin: '0 auto'
+    });
+  });
+
+  it('should provide an empty containerStyle for windows less wide than 16:9', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1200 });
+    Object.defineProperty(window, 'innerHeight', { value: 900 });
+
+    const { result } = renderHook(() => useAspectRatio());
+
+    expect(result.current.containerStyle).toEqual({});
+  });
+
+  it('should update values when window size changes', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1600 });
+    Object.defineProperty(window, 'innerHeight', { value: 900 });
+
+    const { result } = renderHook(() => useAspectRatio());
+
+    expect(result.current.aspectRatio).toBeCloseTo(1.778, 3);
+    expect(result.current.isWiderThan16by9).toBe(false);
+
+    act(() => {
+      Object.defineProperty(window, 'innerWidth', { value: 2560 });
+      Object.defineProperty(window, 'innerHeight', { value: 1080 });
+      resizeCallback();
+    });
+
+    expect(result.current.aspectRatio).toBeCloseTo(2.37, 2);
+    expect(result.current.isWiderThan16by9).toBe(true);
+    expect(result.current.containerStyle).toEqual({
+      maxWidth: `${1080 * (16/9)}px`,
+      margin: '0 auto'
+    });
+  });
+
+  it('should remove the event listener when component unmounts', () => {
+    const { unmount } = renderHook(() => useAspectRatio());
+
+    unmount();
+
+    expect(window.removeEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
+  });
+});

--- a/react/features/base/meet/general/hooks/useAspectRatio.test.ts
+++ b/react/features/base/meet/general/hooks/useAspectRatio.test.ts
@@ -17,12 +17,12 @@ describe('useAspectRatio', () => {
   const RESIZE_WIDTH = 2560;
   const RESIZE_RATIO = RESIZE_WIDTH / RESIZE_HEIGHT;
 
-  let resizeCallback;
+  let resizeCallback: (() => void) | null = null;
 
   beforeEach(() => {
     vi.spyOn(window, 'addEventListener').mockImplementation((event, callback) => {
       if (event === 'resize') {
-        resizeCallback = callback;
+        resizeCallback = callback as () => void;
       }
     });
 
@@ -105,7 +105,9 @@ describe('useAspectRatio', () => {
     act(() => {
       Object.defineProperty(window, 'innerWidth', { value: RESIZE_WIDTH });
       Object.defineProperty(window, 'innerHeight', { value: RESIZE_HEIGHT });
-      resizeCallback();
+      if (resizeCallback) {
+        resizeCallback();
+      }
     });
 
     expect(result.current.aspectRatio).toBeCloseTo(RESIZE_RATIO, 2);

--- a/react/features/base/meet/general/hooks/useAspectRatio.ts
+++ b/react/features/base/meet/general/hooks/useAspectRatio.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Custom hook that detects the current aspect ratio of the window
+ * and determines if it's wider than 16:9
+ *
+ * @returns An object containing:
+ * - aspectRatio: current window aspect ratio
+ * - isWiderThan16by9: boolean indicating if the current ratio is wider than 16:9
+ * - containerStyle: style object to apply to maintain 16:9 ratio
+ */
+export const useAspectRatio = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight
+  });
+
+  useEffect(() => {
+
+    const handleResize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+
+  const aspectRatio = windowSize.width / windowSize.height;
+
+
+  const standard16by9 = 16 / 9;
+
+  const isWiderThan16by9 = aspectRatio > standard16by9;
+
+
+  const containerStyle = isWiderThan16by9
+    ? {
+        maxWidth: `${windowSize.height * standard16by9}px`,
+        margin: '0 auto'
+      }
+    : {};
+
+  return {
+    aspectRatio,
+    isWiderThan16by9,
+    containerStyle
+  };
+};

--- a/react/features/base/meet/views/Conference/components/JoinConference.tsx
+++ b/react/features/base/meet/views/Conference/components/JoinConference.tsx
@@ -177,7 +177,7 @@ class Conference extends AbstractConference<IProps, any> {
                     <Notice />
                     <div onTouchStart={this._onVidespaceTouchStart}>
                         <Header mode={viewMode} translate={t} onSetModeClicked={this._onSetVideoModeClicked} />
-                        <div className="flex">
+                        <div className="flex h-full justify-center items-center">
                             {/* <LargeVideoWeb /> */}
                             <VideoGalleryWrapper videoMode={viewMode} />
                         </div>

--- a/react/features/base/meet/views/Conference/components/VideoGallery.tsx
+++ b/react/features/base/meet/views/Conference/components/VideoGallery.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { VideoParticipantType } from "../types";
 import VideoParticipant from "./VideoParticipant";
+import { useAspectRatio } from "../../../general/hooks/useAspectRatio";
+
 
 export interface VideoGalleryProps {
     participants: VideoParticipantType[];
@@ -10,6 +12,8 @@ export interface VideoGalleryProps {
 
 const VideoGallery = ({ participants, flipX, translate }: VideoGalleryProps) => {
     const participantsNumber = participants.length;
+    const { containerStyle } = useAspectRatio();
+
     const sortedParticipants = [...participants].sort((a, b) => {
         // Local user first
         if (a.local) return -1;
@@ -21,42 +25,49 @@ const VideoGallery = ({ participants, flipX, translate }: VideoGalleryProps) => 
         return a.name.localeCompare(b.name);
     });
 
-    const getParticipantClasses = (index: number) => {
-        let classes = "";
+    const getParticipantClasses = () => {
+        let widthClass = "";
+        let heightClass = "";
 
         if (participantsNumber === 1) {
-            classes = "relative flex-[0_0_80%] max-h-[80vh]";
+            return "relative aspect-video max-h-[75%] max-w-full";
         } else if (participantsNumber === 2) {
-            classes = "relative flex-[0_0_calc(50%-10px)] sm:flex-[0_0_calc(45%-10px)]";
+            widthClass = "w-[calc(50%-5px)]";
+            heightClass = "max-h-[75%]";
         } else if (participantsNumber === 3) {
-            if (index < 2) {
-                classes = "relative flex-[0_0_calc(40%-10px)] sm:flex-[0_0_calc(45%-10px)]";
-            } else {
-                classes = "relative flex-[0_0_calc(40%-10px)] sm:flex-[0_0_calc(45%-10px)]";
-            }
+            widthClass = "w-[calc(33%-10px)]";
+            heightClass = "max-h-[36%]";
         } else if (participantsNumber === 4) {
-            classes = "relative flex-[0_0_calc(50%-10px)] sm:flex-[0_0_calc(45%-10px)]";
+            widthClass = "w-[calc(50%-5px)]";
+            heightClass = "max-h-[36%]";
+        } else if (participantsNumber > 4 && participantsNumber < 10) {
+            widthClass = "w-[calc(33.333%-7px)]";
+            heightClass = "max-h-[24%]";
         } else {
-            classes = "relative flex-[0_0_calc(50%-10px)] sm:flex-[0_0_calc(33.333%-20px)]";
+            widthClass = "w-[calc(25%-7px)]";
+            heightClass = "max-h-[18%]";
         }
 
-        return classes;
+        return `relative ${widthClass} ${heightClass} aspect-video`;
     };
 
     return (
-        <div className="flex h-screen w-full items-center justify-center overflow-hidden">
+        <div className="h-full w-full flex items-center justify-center overflow-hidden bg-gray-950">
             <div
-                className={`flex max-h-4/5 w-full flex-row flex-wrap items-center justify-center gap-2.5 p-2.5 sm:gap-5 sm:p-5`}
+                className="h-[90%] w-[90%] flex justify-center items-center overflow-hidden"
+                style={containerStyle}
             >
-                {sortedParticipants.map((participant, index) => (
-                    <VideoParticipant
-                        key={participant.id}
-                        participant={participant}
-                        className={getParticipantClasses(index)}
-                        translate={translate}
-                        flipX={flipX}
-                    />
-                ))}
+                <div className="max-h-full w-full flex flex-wrap justify-center items-center content-center gap-2.5 overflow-hidden">
+                    {sortedParticipants.map((participant) => (
+                        <VideoParticipant
+                            key={participant.id}
+                            participant={participant}
+                            className={getParticipantClasses()}
+                            translate={translate}
+                            flipX={flipX}
+                        />
+                    ))}
+                </div>
             </div>
         </div>
     );

--- a/react/features/base/meet/views/Conference/components/VideoGallery.tsx
+++ b/react/features/base/meet/views/Conference/components/VideoGallery.tsx
@@ -1,8 +1,7 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { VideoParticipantType } from "../types";
 import VideoParticipant from "./VideoParticipant";
 import { useAspectRatio } from "../../../general/hooks/useAspectRatio";
-
 
 export interface VideoGalleryProps {
     participants: VideoParticipantType[];
@@ -30,34 +29,37 @@ const VideoGallery = ({ participants, flipX, translate }: VideoGalleryProps) => 
         let heightClass = "";
 
         if (participantsNumber === 1) {
-            return "relative aspect-video max-h-[75%] max-w-full";
+            return "relative aspect-square sm:aspect-video max-h-[75%] max-w-full";
         } else if (participantsNumber === 2) {
             widthClass = "w-[calc(50%-5px)]";
-            heightClass = "max-h-[75%]";
+            heightClass = "sm:max-h-[75%]";
         } else if (participantsNumber === 3) {
-            widthClass = "w-[calc(33%-10px)]";
-            heightClass = "max-h-[36%]";
+            widthClass = "w-[calc(33.333%-5px)] sm:w-[calc(33%-10px)]";
+            heightClass = "sm:max-h-[36%]";
         } else if (participantsNumber === 4) {
             widthClass = "w-[calc(50%-5px)]";
-            heightClass = "max-h-[36%]";
+            heightClass = "sm:max-h-[36%]";
         } else if (participantsNumber > 4 && participantsNumber < 10) {
-            widthClass = "w-[calc(33.333%-7px)]";
-            heightClass = "max-h-[24%]";
+            widthClass = "w-[calc(50%-5px)] sm:w-[calc(33.333%-7px)]";
+            heightClass = "sm:max-h-[24%]";
         } else {
-            widthClass = "w-[calc(25%-7px)]";
-            heightClass = "max-h-[18%]";
+            widthClass = "w-[calc(50%-5px)] sm:w-[calc(25%-7px)]";
+            heightClass = "sm:max-h-[18%]";
         }
 
-        return `relative ${widthClass} ${heightClass} aspect-video`;
+
+        const mobileHeightClass = participantsNumber > 4 ? "max-h-[120px]" : "";
+
+        return `relative ${widthClass} ${heightClass} ${mobileHeightClass} aspect-square sm:aspect-video`;
     };
 
     return (
         <div className="h-full w-full flex items-center justify-center overflow-hidden bg-gray-950">
             <div
-                className="h-[90%] w-[90%] flex justify-center items-center overflow-hidden"
+                className={`max-h-[85vh] sm:h-[90%] w-[95%] sm:w-[90%] flex justify-center items-center`}
                 style={containerStyle}
             >
-                <div className="max-h-full w-full flex flex-wrap justify-center items-center content-center gap-2.5 overflow-hidden">
+                <div className="w-full flex flex-wrap justify-center items-start content-start gap-2.5">
                     {sortedParticipants.map((participant) => (
                         <VideoParticipant
                             key={participant.id}

--- a/react/features/base/meet/views/Conference/components/VideoGallery.tsx
+++ b/react/features/base/meet/views/Conference/components/VideoGallery.tsx
@@ -12,6 +12,7 @@ export interface VideoGalleryProps {
 const VideoGallery = ({ participants, flipX, translate }: VideoGalleryProps) => {
     const participantsNumber = participants.length;
     const { containerStyle } = useAspectRatio();
+    const hasOneParticipant = participantsNumber === 1;
 
     const sortedParticipants = [...participants].sort((a, b) => {
         // Local user first
@@ -28,8 +29,8 @@ const VideoGallery = ({ participants, flipX, translate }: VideoGalleryProps) => 
         let widthClass = "";
         let heightClass = "";
 
-        if (participantsNumber === 1) {
-            return "relative aspect-square sm:aspect-video max-h-[75%] max-w-full";
+        if (hasOneParticipant) {
+            return "relative aspect-square sm:aspect-video h-full max-w-full";
         } else if (participantsNumber === 2) {
             widthClass = "w-[calc(50%-5px)]";
             heightClass = "sm:max-h-[75%]";
@@ -59,7 +60,7 @@ const VideoGallery = ({ participants, flipX, translate }: VideoGalleryProps) => 
                 className={`max-h-[85vh] sm:h-[90%] w-[95%] sm:w-[90%] flex justify-center items-center`}
                 style={containerStyle}
             >
-                <div className="w-full flex flex-wrap justify-center items-start content-start gap-2.5">
+                <div className={`${hasOneParticipant ? "h-full": ""} w-full flex flex-wrap justify-center items-start content-start gap-2.5`}>
                     {sortedParticipants.map((participant) => (
                         <VideoParticipant
                             key={participant.id}

--- a/react/features/base/meet/views/Conference/containers/VideoGalleryWrapper.tsx
+++ b/react/features/base/meet/views/Conference/containers/VideoGalleryWrapper.tsx
@@ -8,6 +8,8 @@ import VideoSpeaker from "../components/VideoSpeaker";
 import { VideoParticipantType } from "../types";
 import { getParticipantsWithTracks } from "../utils";
 import AudioTracksContainer from "../../../../../filmstrip/components/web/AudioTracksContainer";
+import { useAspectRatio } from "../../../general/hooks/useAspectRatio";
+
 
 interface GalleryVideoWrapperProps extends WithTranslation {
     videoMode: string;
@@ -16,8 +18,11 @@ interface GalleryVideoWrapperProps extends WithTranslation {
 }
 
 const GalleryVideoWrapper = ({ videoMode, participants, flipX, t }: GalleryVideoWrapperProps) => {
+    const { containerStyle } = useAspectRatio();
+    const contStyle = videoMode === "gallery" ? containerStyle : {};
+
     return (
-        <div className="h-full w-full overflow-hidden bg-gray-950">
+        <div className="h-full w-full bg-gray-950" style={contStyle}>
             <AudioTracksContainer />
             <div className={videoMode === "gallery" ? "block" : "hidden"}>
                 <VideoGallery participants={participants ?? []} translate={t} flipX={flipX} />


### PR DESCRIPTION
## Description

In the gallery view, when there are many participants, they are cut off or overflow the screen, especially on large screen sizes or if the browser window is resized to a less standard size.  
These changes fix that issue, keeping all participants on the screen without the need to resize the window.

## Related Issues

-

## Related Pull Requests

-

## Checklist

-   [x] Changes have been tested locally.
-   [x] Unit tests have been written or updated as necessary.
-   [x] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [x] No new warnings or errors have been introduced.
-   [x] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

- Start a meeting, invite users, and resize window in different sizes to check if participants are visible in gallery view mode.

## Additional Notes

-