### PR TITLE
[PB-3478] feature/Add encoding/decoding button for enable/disable video encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ deploy-init:
 		$(LIBJITSIMEET_DIR)/models/RTC/Decoder.onnx \
 		$(DEPLOY_DIR)/models
 	cp	$(LIBJITSIMEET_DIR)/wasm/RTC/channels.wasm \
-		$(LIBJITSIMEET_DIR)/modules/RTC/channels.js \
+		$(LIBJITSIMEET_DIR)/wasm/RTC/channels.js \
 		$(DEPLOY_DIR)
 	cp -r $(LIBJITSIMEET_DIR)/node_modules/onnxruntime-web/dist \
 	$(DEPLOY_DIR)

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ deploy-init:
 	cp  $(LIBJITSIMEET_DIR)/models/RTC/Encoder.onnx \
 		$(LIBJITSIMEET_DIR)/models/RTC/Decoder.onnx \
 		$(DEPLOY_DIR)/models
-	cp	$(LIBJITSIMEET_DIR)/modules/RTC/channels.wasm \
+	cp	$(LIBJITSIMEET_DIR)/wasm/RTC/channels.wasm \
 		$(LIBJITSIMEET_DIR)/modules/RTC/channels.js \
 		$(DEPLOY_DIR)
 	cp -r $(LIBJITSIMEET_DIR)/node_modules/onnxruntime-web/dist \

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ deploy: deploy-init deploy-appbundle deploy-rnnoise-binary deploy-excalidraw dep
 deploy-init:
 	rm -fr $(DEPLOY_DIR)
 	mkdir -p $(DEPLOY_DIR)/models
-	cp  $(LIBJITSIMEET_DIR)/modules/RTC/models/Encoder.onnx \
-		$(LIBJITSIMEET_DIR)/modules/RTC/models/Decoder.onnx \
+	cp  $(LIBJITSIMEET_DIR)/models/RTC/Encoder.onnx \
+		$(LIBJITSIMEET_DIR)/models/RTC/Decoder.onnx \
 		$(DEPLOY_DIR)/models
 	cp	$(LIBJITSIMEET_DIR)/modules/RTC/channels.wasm \
 		$(LIBJITSIMEET_DIR)/modules/RTC/channels.js \

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,15 @@ deploy: deploy-init deploy-appbundle deploy-rnnoise-binary deploy-excalidraw dep
 
 deploy-init:
 	rm -fr $(DEPLOY_DIR)
-	mkdir -p $(DEPLOY_DIR)
+	mkdir -p $(DEPLOY_DIR)/models
+	cp  $(LIBJITSIMEET_DIR)/modules/RTC/models/Encoder.onnx \
+		$(LIBJITSIMEET_DIR)/modules/RTC/models/Decoder.onnx \
+		$(DEPLOY_DIR)/models
+	cp	$(LIBJITSIMEET_DIR)/modules/RTC/channels.wasm \
+		$(LIBJITSIMEET_DIR)/modules/RTC/channels.js \
+		$(DEPLOY_DIR)
+	cp -r $(LIBJITSIMEET_DIR)/node_modules/onnxruntime-web/dist \
+	$(DEPLOY_DIR)
 
 deploy-appbundle:
 	cp \

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ deploy-init:
 	cp	$(LIBJITSIMEET_DIR)/wasm/RTC/channels.wasm \
 		$(LIBJITSIMEET_DIR)/wasm/RTC/channels.js \
 		$(DEPLOY_DIR)
-	cp -r $(LIBJITSIMEET_DIR)/node_modules/onnxruntime-web/dist \
+	cp -r $(LIBJITSIMEET_DIR)/wasm/ONNX \
 	$(DEPLOY_DIR)
 
 deploy-appbundle:

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "js-md5": "0.6.1",
         "js-sha512": "0.8.0",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "https://github.com/internxt/lib-jitsi-meet/releases/download/v.0.0.3-alpha/lib-internxt-meet-0.0.3.tgz",
+        "lib-jitsi-meet": "https://github.com/internxt/lib-jitsi-meet/releases/download/v.0.0.4-alpha/lib-jitsi-meet-0.0.4-alpha.tgz",
         "lodash": "4.17.21",
         "moment": "2.29.4",
         "moment-duration-format": "2.2.2",

--- a/react/features/base/media/components/web/Video.tsx
+++ b/react/features/base/media/components/web/Video.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactEventHandler, useEffect } from "react";
+import React, { Component, ReactEventHandler } from "react";
 import { ITrack } from "../../../tracks/types";
 import logger from "../../logger";
 
@@ -6,7 +6,6 @@ import logger from "../../logger";
  * The type of the React {@code Component} props of {@link Video}.
  */
 interface IProps {
-
     /**
      * Used to determine the value of the autoplay attribute of the underlying
      * video element.
@@ -18,12 +17,10 @@ interface IProps {
      */
     className: string;
 
-
     /**
      * A map of the event handlers for the video HTML element.
      */
     eventHandlers?: {
-
         /**
          * OnAbort event handler.
          */
@@ -103,7 +100,6 @@ interface IProps {
          * OnWaiting event handler.
          */
         onWaiting?: ReactEventHandler<HTMLVideoElement>;
-
     };
 
     /**
@@ -111,63 +107,63 @@ interface IProps {
      * locate video elements.
      */
     id: string;
-    
+
     /**
      * Used on native.
      */
     mirror?: boolean;
-    
+
     /**
      * The value of the muted attribute for the underlying video element.
      */
     muted?: boolean;
-    
+
     /**
      * Used on native.
      */
     onPlaying?: Function;
-    
+
     /**
      * Used on native.
      */
     onPress?: Function;
-    
+
     /**
      * Optional callback to invoke once the video starts playing.
      */
     onVideoPlaying?: Function;
-    
+
     /**
      * Used to determine the value of the autoplay attribute of the underlying
      * video element.
      */
     playsinline: boolean;
-    
+
     /**
      * Used on native.
      */
     stream?: any;
-    
+
     /**
      * A styles that will be applied on the video element.
      */
     style?: Object;
-    
+
     /**
      * The JitsiLocalTrack to display.
      */
     videoTrack?: Partial<ITrack>;
-    
+
     /**
      * Used on native.
      */
     zOrder?: number;
-    
+
     /**
      * Used on native.
      */
     zoomEnabled?: boolean;
-    
+
     /**
      * Flag to determine if se debe codificar el video
      */

--- a/react/features/base/meet/views/Conference/components/VideoParticipant.tsx
+++ b/react/features/base/meet/views/Conference/components/VideoParticipant.tsx
@@ -5,6 +5,7 @@ import ConnectionIndicator from "../../../../../connection-indicator/components/
 import Video from "../../../../media/components/web/Video";
 import { VideoParticipantType } from "../types";
 import clsx from "clsx";
+import { useVideoEncoding } from "../../PreMeeting/containers/VideoEncodingToggle";
 
 export type VideoParticipantProps = {
     participant: VideoParticipantType;
@@ -17,6 +18,8 @@ const VideoParticipant = ({ participant, className = "", flipX, translate }: Vid
     const { id, name, videoEnabled, audioMuted, videoTrack, local, dominantSpeaker, raisedHand, avatarSource } =
         participant;
 
+    const { isEncodingEnabled } = useVideoEncoding()
+    
     return (
         <div
             className={`flex aspect-square min-w-40 items-center justify-center rounded-[20px] overflow-hidden bg-gray-90 sm:aspect-video ${className}
@@ -28,6 +31,7 @@ const VideoParticipant = ({ participant, className = "", flipX, translate }: Vid
                     videoTrack={{ jitsiTrack: videoTrack }}
                     className={clsx("w-full h-full object-cover", flipX && local && "scale-x-[-1]")}
                     key={`video-${id}`}
+                    encodeVideo={isEncodingEnabled}
                 />
             ) : (
                 <div className="w-full h-full flex items-center justify-center bg-gray-800">

--- a/react/features/base/meet/views/PreMeeting/PreMeetingScreen.tsx
+++ b/react/features/base/meet/views/PreMeeting/PreMeetingScreen.tsx
@@ -25,6 +25,7 @@ import { ErrorModals, ErrorType } from "./components/ErrorModals";
 import Header from "./components/Header";
 import PreMeetingModal from "./components/PreMeetingModal";
 import { useParticipants } from "./hooks/useParticipants";
+import VideoEncodingToggle from "./containers/VideoEncodingToggle";
 import { useUserData } from "./hooks/useUserData";
 
 interface IProps extends WithTranslation {
@@ -336,6 +337,9 @@ const PreMeetingScreen = ({
                         isCreatingConference={!!createConference}
                     />
                 )}
+                <div className="mt-[640px]">
+                    <VideoEncodingToggle />
+                </div>
                 {/* UNCOMMENT IN DEV MODE TO SEE OLD IMPLEMENTATION  */}
                 {/* <div className="flex flex-row">
                     <div>

--- a/react/features/base/meet/views/PreMeeting/containers/VideoEncodingToggle.tsx
+++ b/react/features/base/meet/views/PreMeeting/containers/VideoEncodingToggle.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { useLocalStorage } from "../../../LocalStorageManager";
+import React from "react";
+import { Button } from "@internxt/ui";
+
+const ENCODING_KEY = "videoEncodingEnabled";
+
+const VideoEncodingToggle = () => {
+    const localStorage = useLocalStorage();
+
+    const [isEncodingEnabled, setIsEncodingEnabled] = useState(false);
+
+    useEffect(() => {
+        const savedState = localStorage.get<boolean | string>(ENCODING_KEY, false);
+        setIsEncodingEnabled(savedState === true || savedState === "true");
+    }, []);
+
+    const toggleEncoding = () => {
+        const newState = !isEncodingEnabled;
+        setIsEncodingEnabled(newState);
+        localStorage.set(ENCODING_KEY, newState);
+    };
+
+    return (
+        <div className="flex flex-col items-center p-6 bg-gray-100 rounded-lg shadow-md max-w-md mx-auto">
+            <h2 className="text-xl font-bold mb-4 text-white">Video Encoding</h2>
+
+            <div className="bg-white p-4 rounded-lg shadow-sm w-full mb-4">
+                <div className="flex items-center justify-between">
+                    <span className="text-black">Current status:</span>
+                    <span className={`font-medium ${isEncodingEnabled ? "text-green" : "text-red"}`}>
+                        {isEncodingEnabled ? "Enabled" : "Disabled"}
+                    </span>
+                </div>
+            </div>
+
+            <Button
+                onClick={toggleEncoding}
+            
+            >
+                {isEncodingEnabled ? "Disable Encoding" : "Enable Encoding"}
+            </Button>
+        </div>
+    );
+};
+
+export const useVideoEncoding = () => {
+    const localStorage = useLocalStorage();
+    const [isEncodingEnabled, setIsEncodingEnabled] = useState(false);
+    console.log({isEncodingEnabled})
+    useEffect(() => {
+        const savedState = localStorage.get<boolean | string>(ENCODING_KEY, false);
+        setIsEncodingEnabled(savedState === true || savedState === "true");
+    }, []);
+  
+    const toggleEncoding = () => {
+        const newState = !isEncodingEnabled;
+        setIsEncodingEnabled(newState);
+        localStorage.set(ENCODING_KEY, newState);
+    };
+  
+    return { isEncodingEnabled, toggleEncoding };
+  };
+
+export default VideoEncodingToggle;


### PR DESCRIPTION
## Description

Added to the makefile the files needed to run the onnx models. A button was added to enable and disable the model before entering into the conference.  

## Related Issues

-https://inxt.atlassian.net/browse/PB-3478

## Related Pull Requests

It must be considered the following branch of lib-jitsi-meet:
https://github.com/internxt/lib-jitsi-meet/pull/26/files#

## Checklist

-   [x] Changes have been tested locally.
-   [x] Unit tests have been written or updated as necessary.
-   [ ] The code adheres to the repository's coding standards.
-   [x] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

Locally following the next steps to link lib-jitsi-meet and meet-web

cd lib-jitsi-meet 
sudo npm run build
cd .. 
cd meet-web
sudo npm link lib-jitsi-meet
cd node_modules/lib-jitsi-meet
sudo npm run build
cd ..
cd ..
sudo npm start

At lib-jitsi-meet karma tests were added to check that the models were working as expected.

## Additional Notes

-
