### PR TITLE
[PB-4096] feature/Refactor E2EE activation logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16287,7 +16287,7 @@
         "node_modules/lib-jitsi-meet": {
             "version": "0.0.5-alpha",
             "resolved": "https://github.com/internxt/lib-jitsi-meet/releases/download/v.0.0.5-alpha/lib-jitsi-meet-0.0.5-alpha.tgz",
-            "integrity": "sha512-T8u0Wmzf4xQZl5oOY6zeFhR8YME2Htj2rDCjBpuXnGGzBN9xif3sTiGLq4QM9eDDTj8lq3WVeTUrZAoLUa1eVw==",
+            "integrity": "sha512-wWRz/fXKWYhZr0qxW2h1KZ7dW9cakJRgI/LaW+pyqcN+xzBqHpjHWMKJacBLnBWhYub6sQci3clL4QEQGosDPw==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -16437,9 +16437,9 @@
             "license": "MIT"
         },
         "node_modules/lib-jitsi-meet/node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
             "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
@@ -19437,9 +19437,9 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/protobufjs": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-            "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {

--- a/react/features/base/meet/general/hooks/useE2EEActivation.ts
+++ b/react/features/base/meet/general/hooks/useE2EEActivation.ts
@@ -14,7 +14,7 @@ import { isLocalParticipantModerator } from "../../../participants/functions";
  * - The conference is being displayed (no prejoin or lobby is visible)
  * - There has been a transition from prejoin/lobby to conference
  */
-export const useE2EEActivation = () => {
+export const useE2EEActivation = (isE2EESupported?: boolean) => {
     const dispatch = useDispatch();
 
     const isModerator = useSelector(isLocalParticipantModerator);
@@ -30,7 +30,7 @@ export const useE2EEActivation = () => {
         const wasPrejoinOrLobbyVisible = prevShowStateRef.current.showPrejoin || prevShowStateRef.current.showLobby;
         const isConferenceDisplayed = !_showPrejoin && !_showLobby;
 
-        const shouldActivateE2EE =
+        const shouldActivateE2EE = isE2EESupported &&
             (isConferenceDisplayed && isModerator) ||
             (wasPrejoinOrLobbyVisible && isConferenceDisplayed && isModerator);
 
@@ -42,5 +42,5 @@ export const useE2EEActivation = () => {
             showLobby: _showLobby,
             showPrejoin: _showPrejoin,
         };
-    }, [_showLobby, _showPrejoin, dispatch, isModerator]);
+    }, [_showLobby, _showPrejoin, dispatch, isModerator, isE2EESupported]);
 };

--- a/react/features/base/meet/views/Conference/containers/VideoGalleryWrapper.tsx
+++ b/react/features/base/meet/views/Conference/containers/VideoGalleryWrapper.tsx
@@ -11,10 +11,15 @@ import VideoGallery from "../components/VideoGallery";
 import VideoSpeaker from "../components/VideoSpeaker";
 import { getParticipantsWithTracks } from "../utils";
 
-interface GalleryVideoWrapperProps extends WithTranslation {
+interface OwnProps {
     videoMode: string;
+}
+
+interface MappedStateProps {
     isE2EESupported: boolean;
 }
+
+interface GalleryVideoWrapperProps extends WithTranslation, OwnProps, MappedStateProps {}
 
 const GalleryVideoWrapper = ({ videoMode, t, isE2EESupported }: GalleryVideoWrapperProps) => {
     const { containerStyle } = useAspectRatio();
@@ -38,12 +43,12 @@ const GalleryVideoWrapper = ({ videoMode, t, isE2EESupported }: GalleryVideoWrap
     );
 };
 
-function mapStateToProps(state: IReduxState, galleryProps: GalleryVideoWrapperProps) {
+function mapStateToProps(state: IReduxState, ownProps: OwnProps): MappedStateProps & OwnProps {
     const conference = getCurrentConference(state);
     const isE2EESupported = conference?.isE2EESupported() ?? false;
     return {
-        videoMode: galleryProps.videoMode || "gallery",
-        isE2EESupported
+        ...ownProps,
+        isE2EESupported,
     };
 }
 

--- a/react/features/base/meet/views/Conference/containers/VideoGalleryWrapper.tsx
+++ b/react/features/base/meet/views/Conference/containers/VideoGalleryWrapper.tsx
@@ -3,6 +3,7 @@ import { WithTranslation } from "react-i18next";
 import { connect, useSelector } from "react-redux";
 import { IReduxState } from "../../../../../app/types";
 import AudioTracksContainer from "../../../../../filmstrip/components/web/AudioTracksContainer";
+import { getCurrentConference } from "../../../../conference/functions";
 import { translate } from "../../../../i18n/functions";
 import { useAspectRatio } from "../../../general/hooks/useAspectRatio";
 import { useE2EEActivation } from "../../../general/hooks/useE2EEActivation";
@@ -12,11 +13,12 @@ import { getParticipantsWithTracks } from "../utils";
 
 interface GalleryVideoWrapperProps extends WithTranslation {
     videoMode: string;
+    isE2EESupported: boolean;
 }
 
-const GalleryVideoWrapper = ({ videoMode, t }: GalleryVideoWrapperProps) => {
+const GalleryVideoWrapper = ({ videoMode, t, isE2EESupported }: GalleryVideoWrapperProps) => {
     const { containerStyle } = useAspectRatio();
-    useE2EEActivation();
+    useE2EEActivation(isE2EESupported);
 
     const participants = useSelector((state: IReduxState) => getParticipantsWithTracks(state));
     const flipX = useSelector((state: IReduxState) => state["features/base/settings"].localFlipX);
@@ -37,8 +39,11 @@ const GalleryVideoWrapper = ({ videoMode, t }: GalleryVideoWrapperProps) => {
 };
 
 function mapStateToProps(state: IReduxState, galleryProps: GalleryVideoWrapperProps) {
+    const conference = getCurrentConference(state);
+    const isE2EESupported = conference?.isE2EESupported() ?? false;
     return {
         videoMode: galleryProps.videoMode || "gallery",
+        isE2EESupported
     };
 }
 

--- a/react/features/base/meet/views/PreMeeting/PreMeetingScreen.tsx
+++ b/react/features/base/meet/views/PreMeeting/PreMeetingScreen.tsx
@@ -394,7 +394,7 @@ function mapStateToProps(state: IReduxState, ownProps: Partial<IProps>) {
     const createRoomError = state["features/meet-room"]?.createRoomError ?? false;
 
     const conference = getCurrentConference(state);
-    const isE2EESupported = conference?.isE2EESupported() ?? true;
+    const isE2EESupported = conference?.isE2EESupported() ?? false;
 
     return {
         // For keeping backwards compat.: if we pass an empty hiddenPremeetingButtons


### PR DESCRIPTION
## Description

Refactor E2EE activation logic to make not crash in non compatible browsers and update related components to display that meeting is secure

## Related Issues

-

## Related Pull Requests

-

## Checklist

-   [x] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [ ] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

- Enter to meeting with compatible end to end browsers (chrome, brave), after that if enter to same meet with non compatible (firefox, safari),  those user cannot se the conference unless the owner disable the end to end encryption. 
- Test inverse flow, enter with non compatible and invite a user with a compatible browser. All users have to be able to see video because is not encrypted

## Additional Notes

-