### PR TITLE
Execute virtual background change when select new brackground without…

### DIFF
--- a/react/features/base/meet/views/Settings/SettingsDialog.tsx
+++ b/react/features/base/meet/views/Settings/SettingsDialog.tsx
@@ -79,7 +79,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
     );
 
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+        <div className="fixed inset-0 z-[301] flex items-center justify-center bg-black/60">
             {/* Backdrop */}
             <div className="absolute inset-0" onClick={onClose} />
 

--- a/react/features/base/meet/views/Settings/SettingsDialog.tsx
+++ b/react/features/base/meet/views/Settings/SettingsDialog.tsx
@@ -20,6 +20,9 @@ export interface SettingsDialogProps {
     title: string;
     defaultTab?: string;
     onClose: () => void;
+    submit?: (tabStates: Record<string, any>) => void;
+    cancel?: () => void;
+    dispatch?: any;
 }
 
 const SettingsDialog: React.FC<SettingsDialogProps> = ({
@@ -28,6 +31,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
     title,
     defaultTab,
     onClose,
+    dispatch,
 }) => {
     const allTabs = [...generalTabs, ...accountTabs];
     const [activeTab, setActiveTab] = useState(defaultTab ?? generalTabs[0]?.id);
@@ -183,6 +187,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                                 {...getTabProps(currentTab)}
                                 onTabStateChange={(tabId: number, newState: any) => {
                                     handleTabStateChange(currentTab.id, newState);
+                                    dispatch(currentTab?.submit?.(newState));
                                 }}
                                 tabId={allTabs.findIndex((tab) => tab.id === currentTab.id)}
                             />

--- a/react/features/base/meet/views/Settings/SettingsDialogWrapper.tsx
+++ b/react/features/base/meet/views/Settings/SettingsDialogWrapper.tsx
@@ -51,6 +51,7 @@ const SettingsDialogWrapper: React.FC<IProps> = ({ generalTabs, defaultTab, disp
             title={t("settings.title")}
             defaultTab={defaultTab}
             onClose={onCloseHandler}
+            dispatch={dispatch}
         />
     );
 };

--- a/react/features/base/meet/views/Settings/SettingsDialogWrapper.tsx
+++ b/react/features/base/meet/views/Settings/SettingsDialogWrapper.tsx
@@ -23,8 +23,6 @@ interface IProps {
     generalTabs: TabConfig[];
     defaultTab: string;
     dispatch: IStore["dispatch"];
-    isOpen: boolean;
-    onClose: () => void;
 }
 const EXTERNAL_ACCOUNT_URL = "https://drive.internxt.com/?preferences=open&section=account&subsection=account";
 


### PR DESCRIPTION
## Description

When select virtual background the change does not apply inmediatly.
Now when select new virtual background the change is applied inmmediatly

## Related Issues
-

## Related Pull Requests
-

## Checklist

-   [x] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [ ] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

- Enter to Settings dialog and select new background, close Settings modal and check that preview has changed. Do the same in a meeting

## Additional Notes

