### PR TITLE
[PB-4265] bugfix/Display meeting buttons if user has permission after sign up

### DIFF
--- a/react/features/base/meet/views/Home/HomePage.tsx
+++ b/react/features/base/meet/views/Home/HomePage.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from "react-redux";
 import { appNavigate } from "../../../../app/actions.web";
 import { useLocalStorage } from "../../LocalStorageManager";
 import MeetingButton from "../../general/containers/MeetingButton";
+import { loginSuccess } from "../../general/store/auth/actions";
 import { setRoomID } from "../../general/store/errors/actions";
 import MeetingService from "../../services/meeting.service";
 import { useUserData } from "../PreMeeting/hooks/useUserData";
@@ -139,6 +140,7 @@ const HomePage: React.FC<HomePageProps> = ({ onLogin, translate, startNewMeeting
                 openLogin={openLogin}
                 onClose={() => setIsAuthModalOpen(false)}
                 onLogin={handleSuccessfulLogin}
+                onSignup={(credentials) => dispatch(loginSuccess(credentials))}
                 translate={translate}
             />
             <ScheduleMeetingModal

--- a/react/features/base/meet/views/Home/containers/AuthModal.tsx
+++ b/react/features/base/meet/views/Home/containers/AuthModal.tsx
@@ -1,17 +1,18 @@
 import { Modal } from "@internxt/ui";
 import { X } from "@phosphor-icons/react";
 import React, { useEffect, useState } from "react";
+import { LoginCredentials } from "../../../services/types/command.types";
 import { LoginForm } from "../components/auth/LoginForm";
 import { SignupForm } from "../components/auth/SignUpForm";
 import { Divider } from "../components/Divider";
 import { useLoginModal } from "../hooks/useLoginModal";
-import { OnSignUpPayload, useSignup } from "../hooks/useSignUp";
+import { useSignup } from "../hooks/useSignUp";
 
 interface AuthModalProps {
     isOpen: boolean;
     onClose: () => void;
     onLogin?: (token: string) => void;
-    onSignup?: (signupData: OnSignUpPayload) => void;
+    onSignup?: (signupData: LoginCredentials) => void;
     translate: (key: string) => string;
     openLogin?: boolean;
 }

--- a/react/features/base/meet/views/Home/hooks/useSignUp.test.ts
+++ b/react/features/base/meet/views/Home/hooks/useSignUp.test.ts
@@ -106,7 +106,7 @@ describe("useSignup", () => {
         expect(result.current.signupError).toBe("");
     });
 
-    it("should reset signup state when resetSignupState is called", () => {
+    it("should reset signup state when resetSignupState is called", async () => {
         const { result } = renderHook(() =>
             useSignup({
                 onClose: mockOnClose,
@@ -115,7 +115,7 @@ describe("useSignup", () => {
             })
         );
 
-        act(async () => {
+        await act(async () => {
             mockAuthClient.register.mockRejectedValueOnce(new Error("Test error"));
             await result.current.handleSignup({
                 ...mockFormValues,
@@ -198,10 +198,8 @@ describe("useSignup", () => {
                     id: "direct-id",
                     email: "direct@example.com",
                     uuid: "direct-uuid",
-                    mnemonic: "test-mnemonic",
                 },
             });
-
             const { result } = renderHook(() =>
                 useSignup({
                     onClose: mockOnClose,
@@ -217,13 +215,13 @@ describe("useSignup", () => {
 
             expect(mockOnSignup).toHaveBeenCalled();
             expect(capturedSignupData).toEqual({
+                mnemonic: "test-mnemonic",
                 token: "direct-token",
                 newToken: "direct-new-token",
-                userData: {
+                user: {
                     id: "direct-id",
                     email: "direct@example.com",
                     uuid: "direct-uuid",
-                    mnemonic: "test-mnemonic",
                 },
             });
         });

--- a/react/features/base/meet/views/Home/hooks/useSignUp.ts
+++ b/react/features/base/meet/views/Home/hooks/useSignUp.ts
@@ -6,17 +6,12 @@ import { useLocalStorage } from "../../../LocalStorageManager";
 import { CryptoService } from "../../../services/crypto.service";
 import { KeysService } from "../../../services/keys.service";
 import { SdkManager } from "../../../services/sdk-manager.service";
+import { LoginCredentials } from "../../../services/types/command.types";
 import { IFormValues } from "../types";
-
-export interface OnSignUpPayload {
-    token: string;
-    newToken: string;
-    userData: UserSettings;
-}
 
 interface useSignupProps {
     onClose: () => void;
-    onSignup?: (signupData: OnSignUpPayload) => void;
+    onSignup?: (signupData: LoginCredentials) => void;
     translate: (key: string) => string;
     referrer?: string;
 }
@@ -44,9 +39,10 @@ export const useSignup = ({ onClose, onSignup, translate, referrer }: useSignupP
         storageManager.saveCredentials(token, newToken, mnemonic, user);
 
         onSignup?.({
+            mnemonic,
             token,
             newToken,
-            userData: user,
+            user,
         });
     };
 


### PR DESCRIPTION

## Description

- Handle activation of meeting buttons if user has permissions after sign up

## Related Issues

- 

## Related Pull Requests

- 

## Checklist

-   [x] Changes have been tested locally.
-   [x] Unit tests have been written or updated as necessary.
-   [ ] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

- Sign up and new meetings buttons has to appear if user has permissions (This will only work until we activate the user's subscription tier verification, as, as a general rule, a newly registered user will have the Free Tier and will not be permitted to use Meet)

## Additional Notes

