### PR TITLE
[PB-4907] bgfix/Navigation problems

### DIFF
--- a/react/features/app/actions.web.ts
+++ b/react/features/app/actions.web.ts
@@ -18,7 +18,7 @@ import {
     redirectWithStoredParams,
     reloadWithStoredParams,
 } from "./actions.any";
-import { getDefaultURL, getName } from "./functions.web";
+import { getDefaultURL } from "./functions.web";
 import logger from "./logger";
 import { IStore } from "./types";
 
@@ -60,10 +60,18 @@ export function appNavigate(uri?: string) {
                 // FIXME Turn location's host, hostname, and port properties into
                 // setters in order to reduce the risks of inconsistent state.
                 location.hostname = defaultLocation.hostname;
-                location.pathname =
-                    defaultLocation.pathname === "/new-meeting"
-                        ? "/" + location.pathname.substr(1)
-                        : defaultLocation.pathname + location.pathname.substr(1);
+
+                if (location.pathname === "/") {
+                    const defaultLocation = parseURIString(getDefaultURL(getState));
+                    console.log("Default location:", defaultLocation);
+                    defaultLocation.pathname = "/";
+                    window.history.pushState({}, document.title, defaultLocation.pathname);
+                } else {
+                    location.pathname =
+                        defaultLocation.pathname === "/new-meeting"
+                            ? "/" + location.pathname.substr(1)
+                            : defaultLocation.pathname + location.pathname.substr(1);
+                }
                 location.port = defaultLocation.port;
                 location.protocol = defaultLocation.protocol;
             } else {

--- a/react/features/app/actions.web.ts
+++ b/react/features/app/actions.web.ts
@@ -60,17 +60,10 @@ export function appNavigate(uri?: string) {
                 // FIXME Turn location's host, hostname, and port properties into
                 // setters in order to reduce the risks of inconsistent state.
                 location.hostname = defaultLocation.hostname;
-
-                if (location.pathname === "/") {
-                    const defaultLocation = parseURIString(getDefaultURL(getState));
-                    defaultLocation.pathname = "/";
-                    window.history.pushState({}, document.title, defaultLocation.pathname);
-                } else {
-                    location.pathname =
-                        defaultLocation.pathname === "/new-meeting"
-                            ? "/" + location.pathname.substr(1)
-                            : defaultLocation.pathname + location.pathname.substr(1);
-                }
+                location.pathname =
+                    defaultLocation.pathname === "/new-meeting"
+                        ? "/" + location.pathname.substr(1)
+                        : defaultLocation.pathname + location.pathname.substr(1);
                 location.port = defaultLocation.port;
                 location.protocol = defaultLocation.protocol;
             } else {

--- a/react/features/app/actions.web.ts
+++ b/react/features/app/actions.web.ts
@@ -63,7 +63,6 @@ export function appNavigate(uri?: string) {
 
                 if (location.pathname === "/") {
                     const defaultLocation = parseURIString(getDefaultURL(getState));
-                    console.log("Default location:", defaultLocation);
                     defaultLocation.pathname = "/";
                     window.history.pushState({}, document.title, defaultLocation.pathname);
                 } else {

--- a/react/features/base/meet/views/Home/HomePage.tsx
+++ b/react/features/base/meet/views/Home/HomePage.tsx
@@ -7,6 +7,7 @@ import { loginSuccess } from "../../general/store/auth/actions";
 import { setRoomID } from "../../general/store/errors/actions";
 import MeetingService from "../../services/meeting.service";
 import { useUserData } from "../PreMeeting/hooks/useUserData";
+import { useAppNavigation } from "../PreMeeting/useAppNavigation";
 import AuthModal from "./containers/AuthModal";
 import HeaderWrapper from "./containers/HeaderWrapper";
 import ScheduleMeetingModal from "./containers/ScheduleModal";
@@ -34,6 +35,7 @@ const HomePage: React.FC<HomePageProps> = ({ onLogin, translate, startNewMeeting
     const meetingService = MeetingService.getInstance();
     const storageManager = useLocalStorage();
 
+    useAppNavigation();
     const dispatch = useDispatch();
     const userData = useUserData();
     const isLogged = !!userData;
@@ -41,7 +43,6 @@ const HomePage: React.FC<HomePageProps> = ({ onLogin, translate, startNewMeeting
     const isLargeScreen = windowWidth >= 1024;
     const imageWidth = isLargeScreen ? (windowWidth * 0.4) / 0.6 : "100%";
     const imageHeight = windowHeight * 0.7;
-
     useEffect(() => {
         if (roomID) {
             setMeetingLink(`${MEETING_BASE_URL}${roomID}`);

--- a/react/features/base/meet/views/Home/HomePage.tsx
+++ b/react/features/base/meet/views/Home/HomePage.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from "react-redux";
 import { appNavigate } from "../../../../app/actions.web";
 import { useLocalStorage } from "../../LocalStorageManager";
 import MeetingButton from "../../general/containers/MeetingButton";
+import { loginSuccess } from "../../general/store/auth/actions";
 import { setRoomID } from "../../general/store/errors/actions";
 import MeetingService from "../../services/meeting.service";
 import { useUserData } from "../PreMeeting/hooks/useUserData";
@@ -139,6 +140,7 @@ const HomePage: React.FC<HomePageProps> = ({ onLogin, translate, startNewMeeting
                 openLogin={openLogin}
                 onClose={() => setIsAuthModalOpen(false)}
                 onLogin={handleSuccessfulLogin}
+                onSignup={(credentials) => dispatch(loginSuccess(credentials))}
                 translate={translate}
             />
             <ScheduleMeetingModal

--- a/react/features/base/meet/views/Home/containers/AuthModal.tsx
+++ b/react/features/base/meet/views/Home/containers/AuthModal.tsx
@@ -1,17 +1,18 @@
 import { Modal } from "@internxt/ui";
 import { X } from "@phosphor-icons/react";
 import React, { useEffect, useState } from "react";
+import { LoginCredentials } from "../../../services/types/command.types";
 import { LoginForm } from "../components/auth/LoginForm";
 import { SignupForm } from "../components/auth/SignUpForm";
 import { Divider } from "../components/Divider";
 import { useLoginModal } from "../hooks/useLoginModal";
-import { OnSignUpPayload, useSignup } from "../hooks/useSignUp";
+import { useSignup } from "../hooks/useSignUp";
 
 interface AuthModalProps {
     isOpen: boolean;
     onClose: () => void;
     onLogin?: (token: string) => void;
-    onSignup?: (signupData: OnSignUpPayload) => void;
+    onSignup?: (signupData: LoginCredentials) => void;
     translate: (key: string) => string;
     openLogin?: boolean;
 }

--- a/react/features/base/meet/views/Home/containers/HeaderWrapper.tsx
+++ b/react/features/base/meet/views/Home/containers/HeaderWrapper.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { redirectToStaticPage } from "../../../../../app/actions.any";
-import { appNavigate } from "../../../../../app/actions.web";
 import { openSettingsDialog } from "../../../../../settings/actions.web";
 import MeetingButton from "../../../general/containers/MeetingButton";
 import { useLocalStorage } from "../../../LocalStorageManager";
@@ -43,7 +42,7 @@ const HeaderWrapper = ({ onNewMeeting, onLogin, onSignUp, translate }: HeaderWra
     };
 
     const navigateToHomePage = () => {
-        dispatch(appNavigate("/"));
+        dispatch(redirectToStaticPage("/"));
     };
 
     return (

--- a/react/features/base/meet/views/Home/hooks/useSignUp.test.ts
+++ b/react/features/base/meet/views/Home/hooks/useSignUp.test.ts
@@ -106,7 +106,7 @@ describe("useSignup", () => {
         expect(result.current.signupError).toBe("");
     });
 
-    it("should reset signup state when resetSignupState is called", () => {
+    it("should reset signup state when resetSignupState is called", async () => {
         const { result } = renderHook(() =>
             useSignup({
                 onClose: mockOnClose,
@@ -115,7 +115,7 @@ describe("useSignup", () => {
             })
         );
 
-        act(async () => {
+        await act(async () => {
             mockAuthClient.register.mockRejectedValueOnce(new Error("Test error"));
             await result.current.handleSignup({
                 ...mockFormValues,
@@ -198,10 +198,8 @@ describe("useSignup", () => {
                     id: "direct-id",
                     email: "direct@example.com",
                     uuid: "direct-uuid",
-                    mnemonic: "test-mnemonic",
                 },
             });
-
             const { result } = renderHook(() =>
                 useSignup({
                     onClose: mockOnClose,
@@ -217,13 +215,13 @@ describe("useSignup", () => {
 
             expect(mockOnSignup).toHaveBeenCalled();
             expect(capturedSignupData).toEqual({
+                mnemonic: "test-mnemonic",
                 token: "direct-token",
                 newToken: "direct-new-token",
-                userData: {
+                user: {
                     id: "direct-id",
                     email: "direct@example.com",
                     uuid: "direct-uuid",
-                    mnemonic: "test-mnemonic",
                 },
             });
         });

--- a/react/features/base/meet/views/Home/hooks/useSignUp.ts
+++ b/react/features/base/meet/views/Home/hooks/useSignUp.ts
@@ -6,17 +6,12 @@ import { useLocalStorage } from "../../../LocalStorageManager";
 import { CryptoService } from "../../../services/crypto.service";
 import { KeysService } from "../../../services/keys.service";
 import { SdkManager } from "../../../services/sdk-manager.service";
+import { LoginCredentials } from "../../../services/types/command.types";
 import { IFormValues } from "../types";
-
-export interface OnSignUpPayload {
-    token: string;
-    newToken: string;
-    userData: UserSettings;
-}
 
 interface useSignupProps {
     onClose: () => void;
-    onSignup?: (signupData: OnSignUpPayload) => void;
+    onSignup?: (signupData: LoginCredentials) => void;
     translate: (key: string) => string;
     referrer?: string;
 }
@@ -44,9 +39,10 @@ export const useSignup = ({ onClose, onSignup, translate, referrer }: useSignupP
         storageManager.saveCredentials(token, newToken, mnemonic, user);
 
         onSignup?.({
+            mnemonic,
             token,
             newToken,
-            userData: user,
+            user,
         });
     };
 

--- a/react/features/base/meet/views/PreMeeting/PreMeetingScreen.tsx
+++ b/react/features/base/meet/views/PreMeeting/PreMeetingScreen.tsx
@@ -237,7 +237,7 @@ const PreMeetingScreen = ({
             const locationURL = window.location;
             const baseUrl = `${locationURL.protocol}//${locationURL.host}`;
             const newUrl = `${baseUrl}/new-meeting`;
-            window.history.replaceState({}, document.title, newUrl);
+            window.history.pushState({}, document.title, newUrl);
             dispatch(appNavigate(newUrl));
         } catch (error) {
             console.error("Error creating new meeting:", error);
@@ -294,7 +294,7 @@ const PreMeetingScreen = ({
     };
 
     const navigateToHomePage = () => {
-        dispatch(appNavigate("/"));
+        dispatch(redirectToStaticPage("/"));
     };
 
     return (

--- a/react/features/base/meet/views/PreMeeting/containers/VideoEncodingToggle.tsx
+++ b/react/features/base/meet/views/PreMeeting/containers/VideoEncodingToggle.tsx
@@ -47,7 +47,7 @@ const VideoEncodingToggle = () => {
 export const useVideoEncoding = () => {
     const localStorage = useLocalStorage();
     const [isEncodingEnabled, setIsEncodingEnabled] = useState(false);
-    console.log({isEncodingEnabled})
+
     useEffect(() => {
         const savedState = localStorage.get<boolean | string>(ENCODING_KEY, false);
         setIsEncodingEnabled(savedState === true || savedState === "true");

--- a/react/features/base/meet/views/PreMeeting/useAppNavigation.ts
+++ b/react/features/base/meet/views/PreMeeting/useAppNavigation.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { appNavigate } from "../../../../app/actions.web";
+
+
+export function useAppNavigation() {
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        const handlePopState = () => {
+            console.log("=== PopState Event ===");
+            console.log("Path:", window.location.pathname);
+            console.log("State:", window.history.state);
+            // Importante: NO llamar preventDefault
+            // event.preventDefault();
+            dispatch(appNavigate(window.location.pathname + window.location.search));
+        };
+
+        window.addEventListener("popstate", handlePopState);
+
+        return () => {
+            window.removeEventListener("popstate", handlePopState);
+        };
+    }, [dispatch]);
+}

--- a/react/features/base/meet/views/PreMeeting/useAppNavigation.ts
+++ b/react/features/base/meet/views/PreMeeting/useAppNavigation.ts
@@ -8,10 +8,6 @@ export function useAppNavigation() {
 
     useEffect(() => {
         const handlePopState = () => {
-            console.log("=== PopState Event ===");
-            console.log("Path:", window.location.pathname);
-            console.log("State:", window.history.state);
-
             dispatch(appNavigate(window.location.pathname + window.location.search));
         };
 

--- a/react/features/base/meet/views/PreMeeting/useAppNavigation.ts
+++ b/react/features/base/meet/views/PreMeeting/useAppNavigation.ts
@@ -11,8 +11,7 @@ export function useAppNavigation() {
             console.log("=== PopState Event ===");
             console.log("Path:", window.location.pathname);
             console.log("State:", window.history.state);
-            // Importante: NO llamar preventDefault
-            // event.preventDefault();
+
             dispatch(appNavigate(window.location.pathname + window.location.search));
         };
 

--- a/react/features/welcome/components/WelcomePage.web.tsx
+++ b/react/features/welcome/components/WelcomePage.web.tsx
@@ -12,7 +12,7 @@ import RecentList from "../../recent-list/components/RecentList.web";
 import HomePage from "../../base/meet/views/Home/HomePage";
 import { AbstractWelcomePage, IProps, _mapStateToProps } from "./AbstractWelcomePage";
 
-import { appNavigate } from "../../app/actions.web";
+import { redirectToStaticPage } from "../../app/actions.web";
 import { initializeAuth } from "../../base/meet/general/store/auth/actions";
 import Tabs from "./Tabs";
 
@@ -302,11 +302,7 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
     }*/
 
     _onFormSubmit() {
-        const locationURL = window.location;
-        const baseUrl = `${locationURL.protocol}//${locationURL.host}`;
-        const newUrl = `${baseUrl}/new-meeting`;
-        window.history.pushState({}, document.title, newUrl);
-        this.props.dispatch(appNavigate(newUrl));
+        this.props.dispatch(redirectToStaticPage("/new-meeting"));
     }
 
     /**

--- a/react/features/welcome/components/WelcomePage.web.tsx
+++ b/react/features/welcome/components/WelcomePage.web.tsx
@@ -305,7 +305,7 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
         const locationURL = window.location;
         const baseUrl = `${locationURL.protocol}//${locationURL.host}`;
         const newUrl = `${baseUrl}/new-meeting`;
-        window.history.replaceState({}, document.title, newUrl);
+        window.history.pushState({}, document.title, newUrl);
         this.props.dispatch(appNavigate(newUrl));
     }
 


### PR DESCRIPTION
## Description

This PR fixes navigation issues in the **New-meeting** and **Pre-Join** modals:

- **Issue A — Browser Back button from New-meeting modal**
  - **Steps to Reproduce**
    1. Open the home page (baseurl/).
    2. Click [New Meeting] to navigate to the pre meeting view (baseurl/new-meeting).
    3. Click the browser Back arrow.
  - **Actual Result:** User is not returned to the home page; instead, a new browser tab is opened.
  - **Expected Result:** User should be navigated back to the home page in the same tab.

- **Issue B — Clicking the “X / Meet” icon from New-meeting or Pre-Join**
  - **Steps to Reproduce**
    1. From New-meeting or Pre-Join modal, click the X / Meet icon (app close/back control).
  - **Actual Result:** User goes to the main page, but the URL contains an extra segment (e.g. `…baseurl/5b5f9307-923a-4fe3-994d-7a5b83d5f267` or `…/new-meet`) even though the UI shows the main page.
  - **Expected Result:** User should land on the clean main URL `baseurl/` (without a trailing meeting ID or `/new-meet`).

## Related Issues

-
## Related Pull Requests

- 

## Checklist

-   [x] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [ ] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

- Test cases described on description

## Additional Notes

