### PR TITLE
Changed reorder logic in video gallery view mode

### DIFF
--- a/react/features/base/meet/views/Conference/components/VideoGallery.tsx
+++ b/react/features/base/meet/views/Conference/components/VideoGallery.tsx
@@ -18,9 +18,6 @@ const VideoGallery = ({ participants, flipX, translate }: VideoGalleryProps) => 
         // Local user first
         if (a.local) return -1;
         if (b.local) return 1;
-        // dominantSpeaker next
-        if (a.dominantSpeaker) return -1;
-        if (b.dominantSpeaker) return 1;
         // alfabetical order
         return a.name.localeCompare(b.name);
     });


### PR DESCRIPTION
## Description

Fixes the unexpected frame repositioning behavior in Gallery view during meetings. 
This PR ensures that all participant tiles remain in fixed positions regardless of speaker activity, with active speakers indicated only through visual highlights rather than frame repositioning

## Related Issues

-
## Related Pull Requests
-

## Checklist

-   [x] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [x] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [x] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

- Enter in a meeting with 3 or more users, and check that speaking user not change the position to first one.

## Additional Notes

-