### PR TITLE
Fixed speaker not updating in LargeVideo when it is set speaker mode

### DIFF
--- a/react/features/large-video/actions.any.ts
+++ b/react/features/large-video/actions.any.ts
@@ -34,7 +34,8 @@ export function selectParticipantInLargeVideo(participant?: string) {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
         const state = getState();
 
-        if (isStageFilmstripAvailable(state, 2)) {
+        const { viewMode } = state["features/filmstrip"];
+        if (isStageFilmstripAvailable(state, 2) && viewMode !== "speaker") {
             return;
         }
 


### PR DESCRIPTION
## Description

During a conference, the speaker display mode does not update consistently; sometimes the speaker changes but the speaker video does not.
This change allows the video of the speaker who is speaking to be updated.

## Related Issues

-
## Related Pull Requests

-

## Checklist

-   [x] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [x] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [x] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

Enter in a meeting with three or more participants, change the video mode to Speaker, check that when all are muted and one of them no, the speaker video is updated to the one that is speaking for the users that are listening

## Additional Notes
-