### PR TITLE
[_]: bugfix/Fix displaying upgrade button

### DIFF
--- a/react/features/base/meet/views/Conference/components/VideoParticipant.tsx
+++ b/react/features/base/meet/views/Conference/components/VideoParticipant.tsx
@@ -4,10 +4,10 @@ import clsx from "clsx";
 import React, { useMemo } from "react";
 import ConnectionIndicator from "../../../../../connection-indicator/components/web/ConnectionIndicator";
 import Video from "../../../../media/components/web/Video";
+import { isSafari } from "../../../general/utils/safariDetector";
 import { ConfigService } from "../../../services/config.service";
 import { useVideoEncoding } from "../../PreMeeting/containers/VideoEncodingToggle";
 import { VideoParticipantType } from "../types";
-import { isSafari } from "../../../general/utils/safariDetector";
 
 export type VideoParticipantProps = {
     participant: VideoParticipantType;
@@ -21,13 +21,13 @@ const VideoParticipant = ({ participant, className = "", flipX, translate }: Vid
         participant;
 
     const { isEncodingEnabled } = useVideoEncoding();
-     const encodeVideo = useMemo(() => {
-         if (isSafari()) {
-             return false;
-         }
+    const encodeVideo = useMemo(() => {
+        if (isSafari()) {
+            return false;
+        }
 
-         return ConfigService.instance.isDevelopment() ? isEncodingEnabled : true;
-     }, [isEncodingEnabled]);
+        return ConfigService.instance.isDevelopment() ? isEncodingEnabled : true;
+    }, [isEncodingEnabled]);
 
     return (
         <div
@@ -40,7 +40,7 @@ const VideoParticipant = ({ participant, className = "", flipX, translate }: Vid
                     videoTrack={{ jitsiTrack: videoTrack }}
                     className={clsx("w-full h-full object-cover", flipX && local && "scale-x-[-1]")}
                     key={`video-${id}`}
-                    encodeVideo={encodeVideo}
+                    encodeVideo={false}
                 />
             ) : (
                 <div className="w-full h-full flex items-center justify-center bg-gray-800">

--- a/react/features/base/meet/views/Conference/components/VideoParticipant.tsx
+++ b/react/features/base/meet/views/Conference/components/VideoParticipant.tsx
@@ -21,6 +21,7 @@ const VideoParticipant = ({ participant, className = "", flipX, translate }: Vid
         participant;
 
     const { isEncodingEnabled } = useVideoEncoding();
+    // Encoding will not be used for now, it has decoding problems and video lag. We will leave it set to false.
     const encodeVideo = useMemo(() => {
         if (isSafari()) {
             return false;
@@ -40,6 +41,7 @@ const VideoParticipant = ({ participant, className = "", flipX, translate }: Vid
                     videoTrack={{ jitsiTrack: videoTrack }}
                     className={clsx("w-full h-full object-cover", flipX && local && "scale-x-[-1]")}
                     key={`video-${id}`}
+                    // Set to false due to decoding issues and video lag
                     encodeVideo={false}
                 />
             ) : (

--- a/react/features/base/meet/views/PreMeeting/components/Header.tsx
+++ b/react/features/base/meet/views/PreMeeting/components/Header.tsx
@@ -150,7 +150,7 @@ const RightContent = React.memo(
         };
 
         const planName = getPlanName(subscription);
-        const showUpgrade = isMeetEnabled;
+        const showUpgrade = !isMeetEnabled;
 
         return isLogged ? (
             <div className="flex space-x-2 flex-row">


### PR DESCRIPTION
## Description

- Upgrade button has to be shown when meet is not enabled for that user. Fixed condition to display upgrade button

## Related Issues

-

## Related Pull Requests

-

## Checklist

-   [x] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [ ] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [x] QA Passed

## How Has This Been Tested?

- Open user popup and check if Upgrade button appears when user has account with no permissions to use Meet

## Additional Notes
