### PR TITLE
[_]: Display Show more stats button only in development mode

### DIFF
--- a/react/features/connection-stats/components/ConnectionStatsTable.tsx
+++ b/react/features/connection-stats/components/ConnectionStatsTable.tsx
@@ -6,6 +6,7 @@ import { makeStyles } from 'tss-react/mui';
 import { isMobileBrowser } from '../../base/environment/utils';
 import Icon from '../../base/icons/components/Icon';
 import { IconGear } from '../../base/icons/svg';
+import { ConfigService } from '../../base/meet/services/config.service';
 import ContextMenu from '../../base/ui/components/web/ContextMenu';
 
 type DownloadUpload = {
@@ -774,7 +775,7 @@ const ConnectionStatsTable = ({
                 {_renderStatistics()}
                 <div className = { classes.actions }>
                     {isLocalVideo && enableSaveLogs ? _renderSaveLogs() : null}
-                    {!disableShowMoreStats && _renderShowMoreLink()}
+                    {!disableShowMoreStats && ConfigService.instance.isDevelopment() && _renderShowMoreLink()}
                 </div>
                 {shouldShowMore ? _renderAdditionalStats() : null}
             </div>


### PR DESCRIPTION
## Description

The ‘show more’ button on the connection icon has been hidden in production so as not to give the user innecessary and confusing information

## Related Issues

-
## Related Pull Requests

-

## Checklist

-   [x] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [x] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [x] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

- Enter in a meeting, check that when hover connection icon, show more button is not displayed in production environment

## Additional Notes
