### PR TITLE
[PB-5061] bugfix/Participant not exit properly when is disconnected or kicked

### DIFF
--- a/lang/main-es.json
+++ b/lang/main-es.json
@@ -845,6 +845,7 @@
         "invitedTwoMembers": "{{first}} y {{second}} han sido invitados",
         "joinMeeting": "Unirse",
         "kickParticipant": "{{kicker}} sacó a {{kicked}}",
+        "kickParticipant2": "{{kicked}} ha sido expulsado",
         "leftOneMember": "{{name}} abandonó la reunión",
         "leftThreePlusMembers": "{{name}} y muchos otros abandonaron la reunión",
         "leftTwoMembers": "{{first}} y {{second}} abandonaron la reunión",

--- a/lang/main.json
+++ b/lang/main.json
@@ -899,6 +899,7 @@
         "invitedTwoMembers": "{{first}} and {{second}} have been invited",
         "joinMeeting": "Join",
         "kickParticipant": "{{kicked}} was kicked by {{kicker}}",
+        "kickParticipant2": "{{kicked}} was kicked",
         "leftOneMember": "{{name}} left the meeting",
         "leftThreePlusMembers": "{{name}} and many others left the meeting",
         "leftTwoMembers": "{{first}} and {{second}} left the meeting",

--- a/react/features/base/connection/middleware.web.ts
+++ b/react/features/base/connection/middleware.web.ts
@@ -1,29 +1,46 @@
-import MiddlewareRegistry from '../redux/MiddlewareRegistry';
+import { redirectToStaticPage } from '../../app/actions.any';
+import { showNotification } from "../../notifications/actions";
+import { NOTIFICATION_TIMEOUT } from "../../notifications/constants";
+import MiddlewareRegistry from "../redux/MiddlewareRegistry";
 
-import { CONNECTION_WILL_CONNECT } from './actionTypes';
+import { CONNECTION_DISCONNECTED, CONNECTION_WILL_CONNECT } from "./actionTypes";
 
 /**
  * The feature announced so we can distinguish jibri participants.
  *
  * @type {string}
  */
-export const DISCO_JIBRI_FEATURE = 'http://jitsi.org/protocol/jibri';
+export const DISCO_JIBRI_FEATURE = "http://jitsi.org/protocol/jibri";
 
-MiddlewareRegistry.register(({ getState }) => next => action => {
+MiddlewareRegistry.register(({ getState, dispatch }) => (next) => (action) => {
     switch (action.type) {
-    case CONNECTION_WILL_CONNECT: {
-        const { connection } = action;
-        const { iAmRecorder } = getState()['features/base/config'];
+        case CONNECTION_WILL_CONNECT: {
+            const { connection } = action;
+            const { iAmRecorder } = getState()["features/base/config"];
 
-        if (iAmRecorder) {
-            connection.addFeature(DISCO_JIBRI_FEATURE);
+            if (iAmRecorder) {
+                connection.addFeature(DISCO_JIBRI_FEATURE);
+            }
+
+            // @ts-ignore
+            APP.connection = connection;
+
+            break;
         }
 
-        // @ts-ignore
-        APP.connection = connection;
-
-        break;
-    }
+        case CONNECTION_DISCONNECTED: {
+            console.log("Connection disconnected - redirecting to home");
+            dispatch(
+                showNotification({
+                    titleKey: "dialog.conferenceDisconnectTitle",
+                })
+            ),
+                NOTIFICATION_TIMEOUT.LONG;
+            setTimeout(() => {
+                dispatch(redirectToStaticPage("/"));
+            }, 2000);
+            break;
+        }
     }
 
     return next(action);

--- a/react/features/base/meet/views/Conference/components/InviteUserModal.tsx
+++ b/react/features/base/meet/views/Conference/components/InviteUserModal.tsx
@@ -63,7 +63,11 @@ const InviteUserModal = ({ isOpen, onClose, translate, participantsCount, invite
                             className="w-full pl-10 pr-4 py-2 bg-gray-100 rounded-lg border border-gray-600 focus:outline-none select-all"
                         />
                     </div>
-                    <Button className={`w-full ${copied ? "bg-green-600" : ""}`} onClick={handleCopy}>
+                    <Button
+                        className={`w-full ${copied ? "bg-green-600" : ""}`}
+                        onClick={handleCopy}
+                        disabled={participantsCount === MAX_SIZE_PARTICIPANTS}
+                    >
                         {copied ? (
                             <div className="flex items-center justify-center">
                                 <Check size={18} className="mr-1" />

--- a/react/features/base/participants/actions.ts
+++ b/react/features/base/participants/actions.ts
@@ -544,11 +544,12 @@ export function createVirtualScreenshareParticipant(sourceName: string, local: b
  */
 export function participantKicked(kicker: any, kicked: any) {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
-
+        console.log('participantKicked', kicker, kicked);
         dispatch({
             type: PARTICIPANT_KICKED,
-            kicked: kicked.getId(),
-            kicker: kicker?.getId()
+            kicked: kicked?.getId(),
+            // leave it commented
+            // kicker: kicker?.getId()
         });
 
         if (kicked.isReplaced?.()) {
@@ -559,11 +560,12 @@ export function participantKicked(kicker: any, kicked: any) {
             titleArguments: {
                 kicked:
                     getParticipantDisplayName(getState, kicked.getId()),
-                kicker:
-                    getParticipantDisplayName(getState, kicker.getId())
+                // leave it commented
+                // kicker:
+                //     getParticipantDisplayName(getState, kicker.getId())
             },
-            titleKey: 'notify.kickParticipant'
-        }, NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
+            titleKey: 'notify.kickParticipant2'
+        }, NOTIFICATION_TIMEOUT_TYPE.LONG));
     };
 }
 


### PR DESCRIPTION
## Description

- Fix participant kicked notification and exit from the meeting when participant is disconnected

## Related Issues

-

## Related Pull Requests

-


## Checklist

-   [x] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [ ] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

- Enter with an user account that is already in the meeting, check how is kicked the one that is already in the meeting. User kicked should be disconnected from the meeting.

## Additional Notes

