### PR TITLE
[_] feature/Disabled input selection in InviteUserModal

### DIFF
--- a/react/features/base/meet/views/Conference/components/InviteUserModal.tsx
+++ b/react/features/base/meet/views/Conference/components/InviteUserModal.tsx
@@ -59,8 +59,9 @@ const InviteUserModal = ({ isOpen, onClose, translate, participantsCount, invite
                             type="text"
                             value={inviteLink}
                             readOnly
+                            disabled
                             onClick={(e) => (e.target as HTMLInputElement).select()}
-                            className="w-full pl-10 pr-4 py-2 bg-gray-100 rounded-lg border border-gray-600 focus:outline-none select-all"
+                            className="w-full pl-10 pr-4 py-2 bg-gray-100 rounded-lg border border-gray-600 focus:outline-none select-none pointer-events-none"
                         />
                     </div>
                     <Button


### PR DESCRIPTION
## Description

- Disabled input selection in InviteUserModal

## Related Issues

-

## Related Pull Requests

-

## Checklist

-   [x] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [ ] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

- Check that link in invite users modal inside of a meeting is not selectable 

## Additional Notes
