### PR TITLE
[PB-5064] feature/Notify user if encryption keys sync fails

### DIFF
--- a/lang/main-es.json
+++ b/lang/main-es.json
@@ -909,7 +909,11 @@
         "videoUnmuteBlockedDescription": "Las operaciones de desactivar la cámara y compartir pantalla hansido bloqueadas temporalmente debido a límites del sistema.",
         "videoUnmuteBlockedTitle": "¡Desactivar cámara y compartir pantalla bloqueados!",
         "viewLobby": "Ver lobby",
-        "waitingParticipants": "{{waitingParticipants}} personas"
+        "waitingParticipants": "{{waitingParticipants}} personas",
+        "encryptionKeySyncFailed": "La sincronización de la clave de cifrado ha fallado. Se recomienda salir de la reunión y vuelva a unirse para restaurar la comunicación segura.",
+        "encryptionKeySyncFailedTitle": "Error de Sincronización de Cifrado",
+        "encryptionKeySyncRestored": "La sincronización de claves para el cifrado se ha restaurado con éxito. Su comunicación segura está ahora activa.",
+        "encryptionKeySyncRestoredTitle": "Cifrado Restaurado"
     },
     "participantsPane": {
         "actions": {

--- a/lang/main.json
+++ b/lang/main.json
@@ -968,7 +968,11 @@
         "viewVisitors": "View visitors",
         "waitingParticipants": "{{waitingParticipants}} people",
         "whiteboardLimitDescription": "Please save your progress, as the user limit will soon be reached and the whiteboard will close.",
-        "whiteboardLimitTitle": "Whiteboard usage"
+        "whiteboardLimitTitle": "Whiteboard usage",
+        "encryptionKeySyncFailed": "The encryption key synchronization has failed. It is recommended that you leave the meeting and rejoin to restore secure communication.",
+        "encryptionKeySyncFailedTitle": "Encryption Sync Failed",
+        "encryptionKeySyncRestored": "The encryption key synchronization has been successfully restored. Your secure communication is now active.",
+        "encryptionKeySyncRestoredTitle": "Encryption Restored"
     },
     "participantsPane": {
         "actions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
                 "js-md5": "0.6.1",
                 "js-sha512": "0.8.0",
                 "jwt-decode": "2.2.0",
-                "lib-jitsi-meet": "https://github.com/internxt/lib-jitsi-meet/releases/download/v.0.0.6-alpha/lib-jitsi-meet-0.0.6-alpha.tgz",
+                "lib-jitsi-meet": "https://github.com/internxt/lib-jitsi-meet/releases/download/v.0.0.7-alpha/lib-jitsi-meet-0.0.7-alpha.tgz",
                 "lodash": "4.17.21",
                 "moment": "2.29.4",
                 "moment-duration-format": "2.2.2",
@@ -16417,9 +16417,9 @@
             }
         },
         "node_modules/lib-jitsi-meet": {
-            "version": "0.0.6-alpha",
-            "resolved": "https://github.com/internxt/lib-jitsi-meet/releases/download/v.0.0.6-alpha/lib-jitsi-meet-0.0.6-alpha.tgz",
-            "integrity": "sha512-/jEnAhZXVmBEDL+ZF3EG9U1cad6uRXocYIcKwI/o8WcPQglhNaRow9QPR5BeNAJfAZbZHy1c/o037v+W0P36TA==",
+            "version": "0.0.7-alpha",
+            "resolved": "https://github.com/internxt/lib-jitsi-meet/releases/download/v.0.0.7-alpha/lib-jitsi-meet-0.0.7-alpha.tgz",
+            "integrity": "sha512-sg0Ye/LQwEy5oBPWZlDdWpngpnh9dQMxHmKJXC4mBzN+ovCulTSsz9Wcvum9AdbyA2sgjPQSdY/TXiyDpUw8TA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@jitsi/js-utils": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "js-md5": "0.6.1",
         "js-sha512": "0.8.0",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "https://github.com/internxt/lib-jitsi-meet/releases/download/v.0.0.6-alpha/lib-jitsi-meet-0.0.6-alpha.tgz",
+        "lib-jitsi-meet": "https://github.com/internxt/lib-jitsi-meet/releases/download/v.0.0.7-alpha/lib-jitsi-meet-0.0.7-alpha.tgz",
         "lodash": "4.17.21",
         "moment": "2.29.4",
         "moment-duration-format": "2.2.2",

--- a/react/features/e2ee/middleware.ts
+++ b/react/features/e2ee/middleware.ts
@@ -6,6 +6,8 @@ import { openDialog } from '../base/dialog/actions';
 import { JitsiConferenceEvents } from '../base/lib-jitsi-meet';
 import { ConfigService } from "../base/meet/services/config.service";
 import ParticipantVerificationSASDialog from '../base/meet/views/Conference/components/ParticipantVerificationSASDialog';
+import { showNotification, showWarningNotification } from '../notifications/actions';
+import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
 
 import { PARTICIPANT_JOINED, PARTICIPANT_LEFT } from '../base/participants/actionTypes';
 import { participantUpdated } from '../base/participants/actions';
@@ -157,6 +159,20 @@ StateListenerRegistry.register(
                if (ConfigService.instance.isDevelopment()) {
                    dispatch(openDialog(ParticipantVerificationSASDialog, { sas }));
                }
+             });
+
+             conference.on(JitsiConferenceEvents.E2EE_KEY_SYNC_FAILED, () => {
+                 dispatch(showWarningNotification({
+                     titleKey: 'notify.encryptionKeySyncFailedTitle',
+                     descriptionKey: 'notify.encryptionKeySyncFailed'
+                 }, NOTIFICATION_TIMEOUT_TYPE.STICKY));
+             });
+
+             conference.on(JitsiConferenceEvents.E2EE_KEY_SYNC_AFTER_TIMEOUT, () => {
+                 dispatch(showNotification({
+                     titleKey: 'notify.encryptionKeySyncRestoredTitle',
+                     descriptionKey: 'notify.encryptionKeySyncRestored'
+                 }, NOTIFICATION_TIMEOUT_TYPE.STICKY));
              });
         }
     }


### PR DESCRIPTION
## Description

- Add encryption key synchronization notifications and translations
- 
## Related Issues


## Related Pull Requests



## Checklist

-   [x] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [x] The code adheres to the repository's coding standards.
-   [x] Relevant documentation has been added or updated.
-   [x] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

- In local forcing the fail with library, in production has to happen that sync fail (not common error)

## Additional Notes

