### PR TITLE
[PB-5897] use session storage for anonymous ID

### DIFF
--- a/react/features/base/connection/actions.any.ts
+++ b/react/features/base/connection/actions.any.ts
@@ -15,7 +15,6 @@ import {
 } from '../util/uri';
 
 import { setJoinRoomError } from "../meet/general/store/errors/actions";
-import { LocalStorageManager } from "../meet/LocalStorageManager";
 import MeetingService from "../meet/services/meeting.service";
 import { clearNewMeetingFlowSession } from "../meet/services/sessionStorage.service";
 import {
@@ -33,6 +32,7 @@ import logger from "./logger";
 import { get8x8Options } from "./options8x8";
 import { ConnectionFailedError, IIceServers } from "./types";
 import { ConfigService } from '../meet/services/config.service';
+import { SessionStorageManager } from '../meet/SessionStorageManager';
 
 /**
  * The options that will be passed to the JitsiConnection instance.
@@ -246,7 +246,7 @@ export function _connectInternal({
                 let userUUID: string | undefined;
 
                 if (isAnonymous) {
-                    userUUID = LocalStorageManager.instance.getOrCreateAnonymousUUID();
+                    userUUID = SessionStorageManager.instance.getOrCreateAnonymousUUID();
                 }
                 const { token: jwt, appId } = await MeetingService.instance.joinCall(room, {
                     name: displayName ?? name ?? "",

--- a/react/features/base/connection/actions.web.ts
+++ b/react/features/base/connection/actions.web.ts
@@ -14,6 +14,7 @@ import { LocalStorageManager } from "../meet/LocalStorageManager";
 import MeetingService from "../meet/services/meeting.service";
 import { _connectInternal } from "./actions.any";
 import logger from './logger';
+import { SessionStorageManager } from '../meet/SessionStorageManager';
 
 /**
  * Helper function to leave a call with proper user identification (authenticated or anonymous)
@@ -25,7 +26,7 @@ export async function leaveCallWithUserIdentification(roomId: string): Promise<v
     const user = LocalStorageManager.instance.getUser();
     let payload = undefined;
     if (!user){
-        payload = { userId: LocalStorageManager.instance.getAnonymousUUID() || '' }; 
+        payload = { userId: SessionStorageManager.instance.getAnonymousUUID() || '' }; 
     }
     return await MeetingService.instance.leaveCall(roomId, payload);
 }

--- a/react/features/base/meet/LocalStorageManager.ts
+++ b/react/features/base/meet/LocalStorageManager.ts
@@ -1,5 +1,4 @@
 import { UserSubscription } from "@internxt/sdk/dist/drive/payments/types/types";
-import { v4 } from "uuid";
 import { User } from "./general/store/user/types";
 
 /**
@@ -19,7 +18,6 @@ export class LocalStorageManager {
         MNEMONIC: "xMnemonic",
         USER: "xUser",
         SUBSCRIPTION: "xSubscription",
-        ANONYMOUS_USER_UUID: "xAnonymousUserUUID",
     };
 
     private constructor() {}
@@ -171,41 +169,6 @@ export class LocalStorageManager {
         this.remove(LocalStorageManager.KEYS.SUBSCRIPTION);
     }
 
-    /**
-     * Generates and stores a UUID for anonymous users
-     * @returns The generated or existing UUID
-     */
-    public getOrCreateAnonymousUUID(): string {
-        let uuid = this.get<string>(LocalStorageManager.KEYS.ANONYMOUS_USER_UUID);
-
-        if (!uuid) {
-            uuid = v4();
-            this.set(LocalStorageManager.KEYS.ANONYMOUS_USER_UUID, uuid);
-        }
-
-        return uuid;
-    }
-
-    /**
-     * Gets the anonymous user UUID
-     */
-    public getAnonymousUUID(): string | null | undefined {
-        return this.get<string>(LocalStorageManager.KEYS.ANONYMOUS_USER_UUID);
-    }
-
-    /**
-     * Sets the anonymous user UUID
-     */
-    public setAnonymousUUID(uuid: string): void {
-        this.set(LocalStorageManager.KEYS.ANONYMOUS_USER_UUID, uuid);
-    }
-
-    /**
-     * Removes the anonymous user UUID
-     */
-    public removeAnonymousUUID(): void {
-        this.remove(LocalStorageManager.KEYS.ANONYMOUS_USER_UUID);
-    }
 
     /**
      * Saves the session credentials
@@ -232,7 +195,6 @@ export class LocalStorageManager {
         this.remove(LocalStorageManager.KEYS.MNEMONIC);
         this.remove(LocalStorageManager.KEYS.USER);
         this.remove(LocalStorageManager.KEYS.SUBSCRIPTION);
-        this.remove(LocalStorageManager.KEYS.ANONYMOUS_USER_UUID);
     }
 
     public clearStorage(): void {

--- a/react/features/base/meet/SessionStorageManager.ts
+++ b/react/features/base/meet/SessionStorageManager.ts
@@ -1,0 +1,33 @@
+import { v4 } from "uuid";
+
+const ANON_UUID_KEY = "xAnonymousUserUUID";
+
+export class SessionStorageManager {
+  private static _instance: SessionStorageManager;
+
+  private constructor() {}
+
+  public static get instance(): SessionStorageManager {
+    if (!SessionStorageManager._instance) {
+      SessionStorageManager._instance = new SessionStorageManager();
+    }
+    return SessionStorageManager._instance;
+  }
+
+  public getOrCreateAnonymousUUID(): string {
+    let uuid = this.getAnonymousUUID();
+    if (!uuid) {
+        uuid = v4();
+        sessionStorage.setItem(ANON_UUID_KEY, uuid);
+    }
+   
+    return uuid;
+  }
+
+  public getAnonymousUUID(): string | null {
+    return sessionStorage.getItem(ANON_UUID_KEY);
+  }
+
+}
+
+export default SessionStorageManager.instance;


### PR DESCRIPTION
## Description

Anonymous ID is stored in sessionStorage instead of localStorage. This way, if a user joins from a new private window (incognito mode), a new anonymous ID is assigned. If the user reloads the tab, the anonymous ID is still the same, but for a new private window, it will be different. 

Before, all private windows shared the same anonymous ID.

## Checklist

-   [ ] Changes have been tested locally.
-   [ ] Unit tests have been written or updated as necessary.
-   [ ] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [ ] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

QA in local