### PR TITLE
[PB-6385] Change kickedout notification

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2133,7 +2133,7 @@ export default {
      * @param {boolean} [notifyOnConferenceTermination] whether to notify
      * the user on conference termination
      */
-    hangup(requestFeedback = false, hangupReason, notifyOnConferenceTermination) {
+    hangup(requestFeedback = false, hangupReason, notifyOnConferenceTermination, hangupMessage) {
         APP.store.dispatch(disableReceiver());
 
         this._stopProxyConnection();
@@ -2154,7 +2154,7 @@ export default {
             const feedbackDialogClosed = (feedbackResult = {}) => {
                 if (!feedbackResult.wasDialogShown && hangupReason && notifyOnConferenceTermination) {
                     return APP.store.dispatch(
-                        openLeaveReasonDialog(hangupReason)).then(() => feedbackResult);
+                        openLeaveReasonDialog(hangupReason, hangupMessage)).then(() => feedbackResult);
                 }
 
                 return Promise.resolve(feedbackResult);

--- a/lang/main-es.json
+++ b/lang/main-es.json
@@ -330,6 +330,8 @@
         "incorrectRoomLockPassword": "Contraseña incorrecta",
         "internalError": "¡Ups! Algo salió mal. El siguiente error ocurrió: {{error}}",
         "internalErrorTitle": "Error interno",
+        "kickDuplicateTitle": "Oops! Ya estas en la reunión ",
+        "kickDuplicateMessage": "Parece que ya estabas en la reunión. Prueba a mirar en otra ventana, quiza ya tengas la reunion iniciada.",
         "kickMessage": "Puede ponerse en contacto con {{participantDisplayName}} para obtener más detalles.",
         "kickParticipantButton": "Expulsar",
         "kickParticipantDialog": "¿Seguro que quiere expulsar a este participante?",

--- a/lang/main.json
+++ b/lang/main.json
@@ -376,6 +376,8 @@
         "incorrectRoomLockPassword": "Incorrect password",
         "internalError": "Oops! Something went wrong. The following error occurred: {{error}}",
         "internalErrorTitle": "Internal error",
+        "kickDuplicateTitle": "Oops! You are already in the meeting",
+        "kickDuplicateMessage": "It looks like you already joined this meeting. Try looking into other open windows where you might have the meeting running",
         "kickMessage": "You can contact {{participantDisplayName}} for more details.",
         "kickParticipantButton": "Kick",
         "kickParticipantDialog": "Are you sure you want to kick this participant?",

--- a/react/features/base/connection/actions.web.ts
+++ b/react/features/base/connection/actions.web.ts
@@ -103,7 +103,7 @@ export function connect(id?: string, password?: string) {
  * the user on conference termination.
  * @returns {Function}
  */
-export function hangup(requestFeedback = false, roomId?: string, feedbackTitle?: string, notifyOnConferenceTermination?: boolean) {
+export function hangup(requestFeedback = false, roomId?: string, feedbackTitle?: string, notifyOnConferenceTermination?: boolean, feedbackMessage?: string) {
      // XXX For web based version we use conference hanging up logic from the old app.
     return async (dispatch: IStore["dispatch"]) => {
         if (LocalRecordingManager.isRecordingLocally()) {
@@ -130,7 +130,7 @@ export function hangup(requestFeedback = false, roomId?: string, feedbackTitle?:
 
         await leaveCallWithUserIdentification(roomId);
 
-        return APP.conference.hangup(requestFeedback, feedbackTitle, notifyOnConferenceTermination);
+        return APP.conference.hangup(requestFeedback, feedbackTitle, notifyOnConferenceTermination, feedbackMessage);
     };
 }
 

--- a/react/features/base/meet/views/Conference/components/LeaveWithMessageDialog.tsx
+++ b/react/features/base/meet/views/Conference/components/LeaveWithMessageDialog.tsx
@@ -1,8 +1,8 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from 'tss-react/mui';
 
-import Dialog from '../../../../../base/ui/components/web/Dialog';
+import Dialog from '../../../../ui/components/web/Dialog';
 
 const useStyles = makeStyles()(theme => {
     return {

--- a/react/features/base/meet/views/Conference/components/LeaveWithMessageDialog.tsx
+++ b/react/features/base/meet/views/Conference/components/LeaveWithMessageDialog.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { makeStyles } from 'tss-react/mui';
+
+import Dialog from '../../../../../base/ui/components/web/Dialog';
+
+const useStyles = makeStyles()(theme => {
+    return {
+        dialog: {
+            marginBottom: theme.spacing(1)
+        },
+
+        title: {
+            fontSize: '1.25rem',
+            fontWeight: 'bold',
+            textAlign: 'left'
+        },
+
+        text: {
+            fontSize: '1.25rem'
+        }
+    };
+});
+
+/**
+ * The type of the React {@code Component} props of {@link LeaveReasonDialog}.
+ */
+interface IProps {
+
+    /**
+     * Callback invoked when {@code LeaveReasonDialog} is unmounted.
+     */
+    onClose: () => void;
+
+    /**
+     * The title to display in the dialog.
+     */
+    title?: string;
+
+    message?: string;
+}
+
+/**
+ * A React {@code Component} for displaying a dialog with a reason that ended the conference.
+ *
+ * @param {IProps} props - Component's props.
+ * @returns {JSX}
+ */
+const LeaveWithMessageDialog = ({ onClose, title, message }: IProps) => {
+    const { classes } = useStyles();
+    const { t } = useTranslation();
+
+    useEffect(() => () => {
+        onClose?.();
+    }, []);
+
+    return (
+        <Dialog
+            cancel = {{ hidden: true }}
+            onSubmit = { onClose }
+            size = 'large'
+            testId = 'dialog.leaveReason'>
+            <div className = { classes.dialog }>
+                {title ? <div className = { classes.title }>{t(title)}</div> : null}
+                {message ? <div className = { classes.text }>{t(message)}</div> : null}
+            </div>
+        </Dialog>
+    );
+};
+
+export default LeaveWithMessageDialog;

--- a/react/features/conference/actions.web.ts
+++ b/react/features/conference/actions.web.ts
@@ -5,7 +5,7 @@ import { getJitsiMeetGlobalNSConnectionTimes } from '../base/util/helpers';
 import { getBackendSafeRoomName } from '../base/util/uri';
 
 import { DISMISS_CALENDAR_NOTIFICATION } from './actionTypes';
-import LeaveReasonDialog from './components/web/LeaveReasonDialog.web';
+import LeaveWithMessageDialog from '../base/meet/views/Conference/components/LeaveWithMessageDialog';
 import logger from './logger';
 
 /**
@@ -15,11 +15,12 @@ import logger from './logger';
  *
  * @returns {Promise} Resolved when the dialog is closed.
  */
-export function openLeaveReasonDialog(title?: string) {
+export function openLeaveReasonDialog(title?: string, message?: string) {
     return (dispatch: IStore['dispatch']): Promise<void> => new Promise(resolve => {
-        dispatch(openDialog('LeaveReasonDialog', LeaveReasonDialog, {
+        dispatch(openDialog('LeaveWithMessageDialog', LeaveWithMessageDialog, {
             onClose: resolve,
-            title
+            title,
+            message
         }));
     });
 }

--- a/react/features/conference/middleware.web.ts
+++ b/react/features/conference/middleware.web.ts
@@ -7,7 +7,6 @@ import { openAllowToggleCameraDialog, setCameraFacingMode } from '../base/tracks
 import { CAMERA_FACING_MODE_MESSAGE } from '../base/tracks/constants';
 
 import './middleware.any';
-import { showKickoutDuplicateNotification } from '../base/meet/general/components/KickoutDuplicate';
 
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {

--- a/react/features/conference/middleware.web.ts
+++ b/react/features/conference/middleware.web.ts
@@ -2,12 +2,12 @@ import i18next from 'i18next';
 
 import { ENDPOINT_MESSAGE_RECEIVED, KICKED_OUT } from '../base/conference/actionTypes';
 import { hangup } from '../base/connection/actions.web';
-import { getParticipantDisplayName } from '../base/participants/functions';
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 import { openAllowToggleCameraDialog, setCameraFacingMode } from '../base/tracks/actions.web';
 import { CAMERA_FACING_MODE_MESSAGE } from '../base/tracks/constants';
 
 import './middleware.any';
+import { showKickoutDuplicateNotification } from '../base/meet/general/components/KickoutDuplicate';
 
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
@@ -25,24 +25,20 @@ MiddlewareRegistry.register(store => next => action => {
 
     case KICKED_OUT: {
         const { dispatch, getState } = store;
-        const { participant } = action;
         const { room } = getState()["features/base/conference"];
 
         // we need to first finish dispatching or the notification can be cleared out
         const result = next(action);
 
-        const participantDisplayName
-                = getParticipantDisplayName(store.getState, participant.getId());
-            const roomId = room ?? "";
+        const roomId = room ?? "";
 
-        dispatch(
+       dispatch(
             hangup(
                 true,
                 roomId,
-                participantDisplayName
-                    ? i18next.t("dialog.kickTitle", { participantDisplayName })
-                    : i18next.t("dialog.kickSystemTitle"),
-                true
+                i18next.t("dialog.kickDuplicateTitle"),
+                true,
+                i18next.t("dialog.kickDuplicateMessage"),
             )
         );
 


### PR DESCRIPTION
## Description

This PR changes the message that the user sees when the server kicks them out after detecting duplicated users:


WAS:
<img width="476" height="275" alt="Screenshot 2026-05-21 at 16 44 15" src="https://github.com/user-attachments/assets/38309b8d-1957-4a7d-a650-7a36158d8f1a" />


NOW: 

<img width="724" height="300" alt="Screenshot 2026-05-21 at 17 00 46" src="https://github.com/user-attachments/assets/9fdd2c5c-63bd-4c99-9fc9-3e4b69e12665" />


## Related Pull Requests

[Fix kickout PR](https://github.com/internxt/meet-web/pull/236)

## Checklist

-   [x] Changes have been tested locally.
-   [x] Unit tests have been written or updated as necessary.
-   [x] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [ ] No new warnings or errors have been introduced.
-   [x] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

QA in local

## Additional Notes

Kick out is not working in prod yet

