### PR TITLE
[PB-6384] Don't use generic error for 403

### DIFF
--- a/lang/main-es.json
+++ b/lang/main-es.json
@@ -321,6 +321,8 @@
         "enterDisplayName": "Por favor ingresa tu nombre aquí",
         "error": "Error",
         "errorJoiningMeeting": "Error al unirse a la reunión",
+        "errorJoiningMeetingRoomClosedTitle": "La sala está cerrada",
+        "errorJoiningMeetingRoomClosedMsg": "Esta reunión está actualmente cerrada. Por favor, espera a que el organizador reabra la sala antes de unirte.",
         "gracefulShutdown": "Nuestro servicio se encuentra en mantenimiento. Por favor, intente más tarde.",
         "grantModeratorDialog": "¿Estás seguro de que quieres convertir a este participante en moderador?",
         "grantModeratorTitle": "Convertir en moderador",

--- a/lang/main.json
+++ b/lang/main.json
@@ -366,6 +366,8 @@
         "enterDisplayName": "Enter your name",
         "error": "Error",
         "errorJoiningMeeting": "Error joining meeting",
+        "errorJoiningMeetingRoomClosedTitle": "Room is closed",
+        "errorJoiningMeetingRoomClosedMsg": "This meeting room is currently closed. Please wait for the organizer to reopen the room before joining.",
         "errorRoomCreationRestriction": "You tried to join too quickly, please come back in a bit.",
         "gracefulShutdown": "Our service is currently down for maintenance. Please try again later.",
         "grantModeratorDialog": "Are you sure you want to grant moderator rights to {{participantName}}?",

--- a/react/features/base/connection/actions.any.ts
+++ b/react/features/base/connection/actions.any.ts
@@ -407,17 +407,22 @@ export function _connectInternal({
                     });
                 });
             } catch (error: Error | any) {
-                const errorMessage = error?.message || "Failed to join the meeting";
+                let errorMessage = error?.message || "Failed to join the meeting";
+                let errorTitle = errorMessage;
+                if (error?.status === 403) {
+                    errorMessage = "dialog.errorJoiningMeetingRoomClosedMsg";
+                    errorTitle = "dialog.errorJoiningMeetingRoomClosedTitle";
+                }
 
-                dispatch(setJoinRoomError(true, errorMessage));
+                dispatch(setJoinRoomError(true, errorTitle));
                 dispatch(
                     showErrorNotification(
                         {
-                            titleKey: "dialog.errorJoiningMeeting",
+                            titleKey: errorTitle,
                             descriptionKey: errorMessage,
                             hideErrorSupportLink: true,
                         },
-                        NOTIFICATION_TIMEOUT_TYPE.LONG
+                        NOTIFICATION_TIMEOUT_TYPE.STICKY
                     )
                 );
 

--- a/react/features/base/meet/views/PreMeeting/PreMeetingScreen.tsx
+++ b/react/features/base/meet/views/PreMeeting/PreMeetingScreen.tsx
@@ -374,7 +374,7 @@ const PreMeetingScreen = ({
                     disableJoinButton={disableJoinButton || isCreatingMeeting}
                     flipX={flipX}
                     isCreatingConference={!!createConference}
-                    errorMessage={errorMessage}
+                    errorMessage={t(errorMessage)}
                 />
                 <AuthModal
                     isOpen={isAuthModalOpen}


### PR DESCRIPTION
## Description

WAS:
<img width="501" height="608" alt="Screenshot 2026-05-26 at 14 25 12" src="https://github.com/user-attachments/assets/45da47ac-45b8-485d-97f5-1b83ced60830" />

NOW:
<img width="1221" height="768" alt="Screenshot 2026-05-26 at 16 02 57" src="https://github.com/user-attachments/assets/69c01085-97e6-4f3f-9222-a973070ce960" />
<img width="1437" height="721" alt="Screenshot 2026-05-26 at 16 04 46" src="https://github.com/user-attachments/assets/ad6c71da-38aa-4318-b493-5850859a199f" />


## Related Issues
Fixes [#PB-6384](https://inxt.atlassian.net/browse/PB-6384)


## Checklist

-   [x] Changes have been tested locally.
-   [x] Unit tests have been written or updated as necessary.
-   [x] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [x] No new warnings or errors have been introduced.
-   [x] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?
QA in local

## Additional Notes

We need to add more translations
