### PR TITLE
[PB-6468] change 400 to user-friendly message

### DIFF
--- a/lang/main-es.json
+++ b/lang/main-es.json
@@ -323,6 +323,8 @@
         "errorJoiningMeeting": "Error al unirse a la reunión",
         "errorJoiningMeetingRoomClosedTitle": "La sala está cerrada",
         "errorJoiningMeetingRoomClosedMsg": "Esta reunión está actualmente cerrada. Por favor, espera a que el organizador reabra la sala antes de unirte.",
+        "errorJoiningMeetingRoomFullTitle": "La sala está llena",
+        "errorJoiningMeetingRoomFullMsg": "Esta reunión está actualmente llena. Por favor, contacta con el organizador o inténtalo más tarde.",
         "gracefulShutdown": "Nuestro servicio se encuentra en mantenimiento. Por favor, intente más tarde.",
         "grantModeratorDialog": "¿Estás seguro de que quieres convertir a este participante en moderador?",
         "grantModeratorTitle": "Convertir en moderador",

--- a/lang/main.json
+++ b/lang/main.json
@@ -368,6 +368,8 @@
         "errorJoiningMeeting": "Error joining meeting",
         "errorJoiningMeetingRoomClosedTitle": "Room is closed",
         "errorJoiningMeetingRoomClosedMsg": "This meeting room is currently closed. Please wait for the organizer to reopen the room before joining.",
+        "errorJoiningMeetingRoomFullTitle": "Room is full",
+        "errorJoiningMeetingRoomFullMsg": "This meeting room is currently full. Please contact the organizer or try again later.",
         "errorRoomCreationRestriction": "You tried to join too quickly, please come back in a bit.",
         "gracefulShutdown": "Our service is currently down for maintenance. Please try again later.",
         "grantModeratorDialog": "Are you sure you want to grant moderator rights to {{participantName}}?",

--- a/react/features/base/connection/actions.any.ts
+++ b/react/features/base/connection/actions.any.ts
@@ -413,6 +413,10 @@ export function _connectInternal({
                     errorMessage = "dialog.errorJoiningMeetingRoomClosedMsg";
                     errorTitle = "dialog.errorJoiningMeetingRoomClosedTitle";
                 }
+                if (error?.status === 400) {
+                    errorMessage = "dialog.errorJoiningMeetingRoomFullMsg";
+                    errorTitle = "dialog.errorJoiningMeetingRoomFullTitle";
+                }
 
                 dispatch(setJoinRoomError(true, errorTitle));
                 dispatch(


### PR DESCRIPTION
## Description

When the room is full, it shows a 400 error instead of a user-friendly one; this PR fixes it.

Was: 
<img width="1440" height="724" alt="Screenshot 2026-06-02 at 09 35 32" src="https://github.com/user-attachments/assets/77726245-b934-4dd9-accd-6e366f2e6d5c" />


Now:
<img width="1011" height="711" alt="Screenshot 2026-06-02 at 12 16 27" src="https://github.com/user-attachments/assets/9c58ea68-20bb-4fec-981d-26c916b20f45" />



## Related Issues

[PB-6468](https://inxt.atlassian.net/browse/PB-6468)

## Checklist

-   [x] Changes have been tested locally.
-   [x] Unit tests have been written or updated as necessary.
-   [x] The code adheres to the repository's coding standards.
-   [ ] Relevant documentation has been added or updated.
-   [x] No new warnings or errors have been introduced.
-   [x] SonarCloud issues have been reviewed and addressed.
-   [ ] QA Passed

## How Has This Been Tested?

QA in local

[PB-6468]: https://inxt.atlassian.net/browse/PB-6468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ